### PR TITLE
ROLES.md compliance: roles, night-resolver fixes, day actions, dashboard

### DIFF
--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/controller/GameController.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/controller/GameController.kt
@@ -6,6 +6,7 @@ import dev.robothanzo.werewolf.controller.dto.ForcePoliceRequest
 import dev.robothanzo.werewolf.controller.dto.KillRequest
 import dev.robothanzo.werewolf.controller.dto.PoliceTransferRequest
 import dev.robothanzo.werewolf.controller.dto.ReviveRequest
+import dev.robothanzo.werewolf.controller.dto.TargetRequest
 import dev.robothanzo.werewolf.game.flow.GameFlowService
 import dev.robothanzo.werewolf.controller.dto.TimerRequest
 import dev.robothanzo.werewolf.discord.DiscordGateway
@@ -14,6 +15,8 @@ import dev.robothanzo.werewolf.domain.LogSeverity
 import dev.robothanzo.werewolf.game.flow.GameScheduler
 import dev.robothanzo.werewolf.domain.Phase
 import dev.robothanzo.werewolf.security.annotations.CanManageGuild
+import dev.robothanzo.werewolf.service.CourtAnnouncer
+import dev.robothanzo.werewolf.service.DayOrchestrator
 import dev.robothanzo.werewolf.service.GameActionService
 import dev.robothanzo.werewolf.service.GameSessionService
 import dev.robothanzo.werewolf.service.NightOrchestrator
@@ -36,9 +39,23 @@ class GameController(
     private val sessionService: GameSessionService,
     private val flow: GameFlowService,
     private val night: NightOrchestrator,
+    private val day: DayOrchestrator,
+    private val announcer: CourtAnnouncer,
     private val gateway: DiscordGateway,
     private val gameScheduler: GameScheduler,
 ) {
+
+    /** Run the orchestrator that owns the phase we just entered (night actions / day flow). */
+    private fun onPhaseEntered(guildId: Long, phase: Phase) {
+        when (phase) {
+            Phase.NIGHT -> night.startNight(guildId)
+            Phase.DAWN -> day.enterDawn(guildId)
+            Phase.POLICE_ELECTION -> day.startPoliceElection(guildId)
+            Phase.SPEECHES -> day.startSpeeches(guildId)
+            Phase.EXPEL_VOTE -> day.startExpelVote(guildId)
+            else -> {}
+        }
+    }
 
     @Operation(summary = "Assign identities", description = "Deal the identity pool to the eligible members.")
     @ApiResponses(value = [SwaggerApiResponse(responseCode = "200", description = "Assigned")])
@@ -68,6 +85,44 @@ class GameController(
         @RequestBody body: KillRequest,
     ): ResponseEntity<ApiResponse> {
         actions.kill(guildId.toLong(), seat, body.identityIndex, body.allowLastWords)
+        return ResponseEntity.ok(ApiResponse.ok())
+    }
+
+    @Operation(summary = "Fire a revenge shot", description = "Fire an armed 獵人 / 狼王 / 白狼王 revenge at a target.")
+    @ApiResponses(value = [SwaggerApiResponse(responseCode = "200", description = "Fired")])
+    @PostMapping("/seats/{seat}/revenge")
+    @CanManageGuild
+    fun revenge(
+        @PathVariable guildId: String,
+        @PathVariable seat: Int,
+        @RequestBody body: TargetRequest,
+    ): ResponseEntity<ApiResponse> {
+        actions.revenge(guildId.toLong(), seat, body.target)
+        return ResponseEntity.ok(ApiResponse.ok())
+    }
+
+    @Operation(summary = "騎士 決鬥", description = "Knight duels a seat; a wolf hit enters night, a miss kills the knight.")
+    @ApiResponses(value = [SwaggerApiResponse(responseCode = "200", description = "Resolved")])
+    @PostMapping("/seats/{seat}/duel")
+    @CanManageGuild
+    fun duel(
+        @PathVariable guildId: String,
+        @PathVariable seat: Int,
+        @RequestBody body: TargetRequest,
+    ): ResponseEntity<ApiResponse> {
+        if (day.knightDuel(guildId.toLong(), seat, body.target)) onPhaseEntered(guildId.toLong(), Phase.NIGHT)
+        return ResponseEntity.ok(ApiResponse.ok())
+    }
+
+    @Operation(summary = "自爆", description = "A wolf self-destructs, forcing night (白狼王 may then带人, 血月使徒 seals the night).")
+    @ApiResponses(value = [SwaggerApiResponse(responseCode = "200", description = "Detonated")])
+    @PostMapping("/seats/{seat}/self-destruct")
+    @CanManageGuild
+    fun selfDestruct(
+        @PathVariable guildId: String,
+        @PathVariable seat: Int,
+    ): ResponseEntity<ApiResponse> {
+        if (day.selfDestruct(guildId.toLong(), seat)) onPhaseEntered(guildId.toLong(), Phase.NIGHT)
         return ResponseEntity.ok(ApiResponse.ok())
     }
 
@@ -130,7 +185,7 @@ class GameController(
             require(s.assigned) { "error.not_assigned" }
             val t = flow.start(); s.phase = t.phase; s.day = t.day; t.phase
         }
-        if (entered == Phase.NIGHT) night.startNight(guildId.toLong())
+        onPhaseEntered(guildId.toLong(), entered)
         return ResponseEntity.ok(ApiResponse.ok())
     }
 
@@ -142,7 +197,7 @@ class GameController(
         val entered = sessionService.mutate(guildId.toLong()) { s ->
             val t = flow.next(s.phase, s.day); s.phase = t.phase; s.day = t.day; t.phase
         }
-        if (entered == Phase.NIGHT) night.startNight(guildId.toLong())
+        onPhaseEntered(guildId.toLong(), entered)
         return ResponseEntity.ok(ApiResponse.ok())
     }
 
@@ -187,6 +242,7 @@ class GameController(
             s.timerEndsAt = timerEndsAt
             sessionService.log(guildId.toLong(), LogSeverity.ACTION, "timer.start", seconds)
         }
+        announcer.announce(guildId.toLong(), "timer.start", seconds)
 
         // Schedule final timer completion
         val delay = seconds * 1000L
@@ -196,6 +252,7 @@ class GameController(
                 sessionService.log(guildId.toLong(), LogSeverity.ALERT, "timer.ended")
             }
             gateway.playSound(guildId.toLong(), SoundCue.TIMER_ENDED)
+            announcer.announce(guildId.toLong(), "timer.ended")
         }
 
         // Schedule 30-seconds-remaining warning if timer is > 30s
@@ -218,6 +275,7 @@ class GameController(
             s.timerEndsAt = null
             sessionService.log(guildId.toLong(), LogSeverity.ACTION, "timer.stopped")
         }
+        announcer.announce(guildId.toLong(), "timer.stopped")
         gameScheduler.cancel(guildId.toLong(), GameScheduler.TIMER)
         gameScheduler.cancel(guildId.toLong(), "timer.warn")
         return ResponseEntity.ok(ApiResponse.ok())

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/controller/SettingsController.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/controller/SettingsController.kt
@@ -66,4 +66,22 @@ class SettingsController(
         sessionService.mutate(guildId.toLong()) { s -> s.settings.muteAfterSpeech = body.value }
         return ResponseEntity.ok(ApiResponse.ok())
     }
+
+    @Operation(summary = "Toggle witch self-save", description = "Enable/disable 女巫自救 (ROLES.md 女巫 房規).")
+    @ApiResponses(value = [SwaggerApiResponse(responseCode = "200", description = "Updated")])
+    @PostMapping("/witch-self-save")
+    @CanManageGuild
+    fun witchSelfSave(@PathVariable guildId: String, @RequestBody body: ToggleRequest): ResponseEntity<ApiResponse> {
+        sessionService.mutate(guildId.toLong()) { s -> s.settings.witchSelfSave = body.value }
+        return ResponseEntity.ok(ApiResponse.ok())
+    }
+
+    @Operation(summary = "Toggle hidden-wolf knife", description = "Enable/disable 隱狼繼承狼刀 (ROLES.md 隱狼 房規).")
+    @ApiResponses(value = [SwaggerApiResponse(responseCode = "200", description = "Updated")])
+    @PostMapping("/hidden-wolf-knife")
+    @CanManageGuild
+    fun hiddenWolfKnife(@PathVariable guildId: String, @RequestBody body: ToggleRequest): ResponseEntity<ApiResponse> {
+        sessionService.mutate(guildId.toLong()) { s -> s.settings.hiddenWolfInheritsKnife = body.value }
+        return ResponseEntity.ok(ApiResponse.ok())
+    }
 }

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/controller/dto/GameSnapshot.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/controller/dto/GameSnapshot.kt
@@ -19,6 +19,8 @@ data class GameSnapshot(
     val started: Boolean,
     val doubleIdentity: Boolean,
     val muteAfterSpeech: Boolean,
+    val witchSelfSave: Boolean,
+    val hiddenWolfInheritsKnife: Boolean,
     val assigned: Boolean,
     val policeSeat: Int?,
     val aliveCount: Int,
@@ -49,6 +51,13 @@ data class SeatDto(
     val clone: Boolean,
     val idiot: Boolean,
     val orderLocked: Boolean,
+    // --- ROLES.md behavioural state surfaced for judge action buttons ---
+    val revengePending: Boolean,
+    val idiotRevealed: Boolean,
+    val loverSeat: Int?,
+    val charmedSeat: Int?,
+    val learnedRoleId: String?,
+    val knifeArmed: Boolean,
 )
 
 @Schema(description = "One identity card on a seat")

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/controller/dto/RequestDtos.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/controller/dto/RequestDtos.kt
@@ -10,6 +10,12 @@ data class KillRequest(
     val allowLastWords: Boolean = false,
 )
 
+@Schema(description = "Pick a target seat (revenge shot, knight duel)")
+data class TargetRequest(
+    @Schema(description = "The seat being targeted")
+    val target: Int,
+)
+
 @Schema(description = "Revive a seat or a single identity")
 data class ReviveRequest(
     @Schema(description = "Index of the identity to revive; null revives the whole seat")

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/domain/GameSession.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/domain/GameSession.kt
@@ -1,5 +1,7 @@
 package dev.robothanzo.werewolf.domain
 
+import dev.robothanzo.werewolf.game.speech.SpeechFlow
+import dev.robothanzo.werewolf.game.vote.Poll
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 
@@ -45,6 +47,18 @@ data class GameSession(
 
     /** Current night round (active during the NIGHT phase). */
     var nightState: NightState = NightState(),
+
+    /** Active day speech flow (SPEECHES / police campaign / last words), or null when idle. */
+    var speech: SpeechFlow? = null,
+
+    /** Active day poll (police election or expel vote), or null when idle. */
+    var poll: Poll? = null,
+
+    /** Seat number of the most recently expelled (voted-out) player — the 守墓人 reads its faction. */
+    var lastExpelledSeat: Int? = null,
+
+    /** 血月使徒 自爆 seals the next night: all 神職 abilities void + the wolves cannot knife. */
+    var bloodMoonSeal: Boolean = false,
 ) {
     val playerCount: Int get() = settings.playerCount
 
@@ -58,6 +72,10 @@ data class GameSettings(
     var playerCount: Int = 12,
     var doubleIdentity: Boolean = false,
     var muteAfterSpeech: Boolean = true,
+    /** 女巫 房規: whether the witch may use her antidote on herself (ROLES.md 女巫). */
+    var witchSelfSave: Boolean = false,
+    /** 隱狼 房規: whether 隱狼 inherits the wolf knife once the chat wolves are dead (ROLES.md 隱狼). */
+    var hiddenWolfInheritsKnife: Boolean = true,
 ) {
     /** Required pool size: N for single, 2N for double identity. */
     val requiredPoolSize: Int get() = if (doubleIdentity) playerCount * 2 else playerCount

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/domain/Seat.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/domain/Seat.kt
@@ -21,6 +21,23 @@ data class Seat(
     var idiot: Boolean = false,
     /** Whether the identity-order swap is locked (120 s after assignment). */
     var orderLocked: Boolean = false,
+    // --- ROLES.md behavioural state (default-safe, Mongo-additive) ---
+    /** 邱比特 lover bond (bidirectional); the two lovers 殉情 together. */
+    var loverSeat: Int? = null,
+    /** 狼美人 current charm victim — persisted so daytime 殉情 can cascade. */
+    var charmedSeat: Int? = null,
+    /** An armed but unfired DEATH_REVENGE shot (獵人 / 狼王 / 白狼王). */
+    var revengePending: Boolean = false,
+    /** 白癡 has flipped its card on expel: stays alive but loses its vote. */
+    var idiotRevealed: Boolean = false,
+    /** 機械狼 learned identity (its abilities/reads follow this id). */
+    var learnedRoleId: String? = null,
+    /** 石像鬼 / 隱狼 has inherited the wolf knife (the chat wolves are gone). */
+    var knifeArmed: Boolean = false,
+    /** 騎士 has spent its one-shot day duel. */
+    var duelUsed: Boolean = false,
+    /** 血月使徒 has used its one-shot 最後一狼 survival on expel. */
+    var bloodMoonRevived: Boolean = false,
 ) {
     /** Zero-padded seat name, e.g. seat 3 → "03" (used as 玩家03). */
     val paddedNumber: String get() = number.toString().padStart(2, '0')

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/game/day/DuelResolver.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/game/day/DuelResolver.kt
@@ -1,0 +1,30 @@
+package dev.robothanzo.werewolf.game.day
+
+import dev.robothanzo.werewolf.domain.Faction
+import dev.robothanzo.werewolf.domain.GameSession
+import dev.robothanzo.werewolf.game.roles.RoleRegistry
+import org.springframework.stereotype.Service
+
+/** Outcome of a 騎士 決鬥: who dies, and whether the target was a wolf (which forces night). */
+data class DuelResult(val targetIsWolf: Boolean, val deadSeat: Int)
+
+/**
+ * Pure resolution of the 騎士 決鬥 (ROLES.md 騎士): if the dueled seat is wolf-faction the target
+ * dies (and the day ends, entering night); otherwise the knight dies "以死謝罪" and the day
+ * continues. The death side-effects + phase transition are applied by `DayOrchestrator`.
+ */
+@Service
+class DuelResolver(private val roles: RoleRegistry) {
+
+    fun resolve(session: GameSession, knightSeat: Int, targetSeat: Int): DuelResult {
+        val target = session.seat(targetSeat)
+        val card = target?.livingCards()?.firstOrNull() ?: target?.cards?.firstOrNull()
+        val faction = when {
+            target == null || card == null -> Faction.GOD
+            target.clone -> Faction.GOD
+            else -> roles.factionOf(card.roleId)
+        }
+        val targetIsWolf = faction == Faction.WOLF
+        return DuelResult(targetIsWolf, if (targetIsWolf) targetSeat else knightSeat)
+    }
+}

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/game/night/Effect.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/game/night/Effect.kt
@@ -39,6 +39,9 @@ enum class Effect {
     /** 黑市商人 trade. */
     TRADE,
 
+    /** 機械狼 learns a player's identity (copied into the actor's learnedRoleId). */
+    LEARN,
+
     /** Terminal channel: a death has been declared (resolution output). */
     DEATH,
 }

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/game/night/NightResolver.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/game/night/NightResolver.kt
@@ -2,6 +2,7 @@ package dev.robothanzo.werewolf.game.night
 
 import dev.robothanzo.werewolf.domain.Faction
 import dev.robothanzo.werewolf.domain.GameSession
+import dev.robothanzo.werewolf.game.roles.RoleIds
 import dev.robothanzo.werewolf.game.roles.RoleRegistry
 import org.springframework.stereotype.Service
 
@@ -84,18 +85,23 @@ class NightResolver(private val roles: RoleRegistry) {
             }
         }
 
+        // 女巫不可自救 (房規 toggle): a save on the witch's own seat is void unless 自救 is enabled.
+        val selfSaveBlocked = decls.witchSave != null &&
+            decls.witchSave == decls.witchActor && !session.settings.witchSelfSave
+
         // 3. Wolf knife vs guard vs witch save.
         if (wolfKill != null && !voided(wolfKill) && wolfKill.target != null) {
             val t = wolfKill.target
             val guarded = guard != null && !voided(guard) && guard.target == t
-            val saved = !witchVoided && witchSave == t
+            val saved = !witchVoided && !selfSaveBlocked && witchSave == t
             // 同守同救 = 死: protection and antidote on the same seat cancel; the seat still dies.
             val dies = if (guarded && saved) true else !(guarded || saved)
             if (dies) addDeath(t, "night.death")
         }
 
-        // 4. 女巫 poison — cannot be guarded; blocks the victim's revenge.
-        if (!witchVoided) {
+        // 4. 女巫 poison — cannot be guarded; blocks the victim's revenge. 獵魔人 is immune to other
+        // gods' night abilities (ROLES.md 獵魔人 被動), so poison cannot kill it.
+        if (!witchVoided && witchPoison != null && roleIdOfSeat(session, witchPoison) != RoleIds.DEMON_HUNTER) {
             addDeath(witchPoison, "night.death", suppressRevenge = true)
         }
 
@@ -138,5 +144,12 @@ class NightResolver(private val roles: RoleRegistry) {
         val s = session.seat(seat) ?: return null
         val card = s.livingCards().firstOrNull() ?: s.cards.firstOrNull() ?: return null
         return if (s.clone) Faction.GOD else roles.factionOf(card.roleId)
+    }
+
+    /** The (living) role id held by a seat — used for passive role checks like 獵魔人 immunity. */
+    private fun roleIdOfSeat(session: GameSession, seat: Int): String? {
+        val s = session.seat(seat) ?: return null
+        val card = s.livingCards().firstOrNull() ?: s.cards.firstOrNull() ?: return null
+        return card.roleId
     }
 }

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/game/night/abilities/NightAbilities.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/game/night/abilities/NightAbilities.kt
@@ -90,6 +90,13 @@ class BlackMerchantTrade : SimpleNightAbility(
     "black_merchant.trade", RoleIds.BLACK_MERCHANT, reads = setOf(SWAP, FEAR), writes = setOf(TRADE),
 )
 
+/** 機械狼 — one-shot learn: copies the chosen seat's identity into the actor's learnedRoleId, after
+ *  which it acts as the learned role on later nights (ROLES.md 機械狼 主動技). */
+@Component
+class MechanicWolfLearn : SimpleNightAbility(
+    "mechanic_wolf.learn", RoleIds.MECHANIC_WOLF, reads = setOf(SWAP, FEAR), writes = setOf(Effect.LEARN),
+)
+
 /** 獵魔人 hunts a seat; resolves to a death immediately (good → self-death, wolf → target death).
  *  Cannot be used on the first night. */
 @Component

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/game/roles/Role.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/game/roles/Role.kt
@@ -21,6 +21,15 @@ enum class RoleTag {
 
     /** First-night-only ability (邱比特 / 盜賊 / 混血兒). */
     FIRST_NIGHT_ONLY,
+
+    /** Reads as 好人 to 預言家 / 通靈師 investigations (隱狼). */
+    INVESTIGATED_AS_GOOD,
+
+    /** Inherits the wolf knife once the chat wolves are dead (石像鬼 / 隱狼 / 機械狼). */
+    INHERITS_KILL,
+
+    /** Death-revenge fires only via 自爆, never on a normal death (白狼王). */
+    REVENGE_ON_SELF_DESTRUCT_ONLY,
 }
 
 /**

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/game/roles/RoleIds.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/game/roles/RoleIds.kt
@@ -32,4 +32,5 @@ object RoleIds {
     const val PSYCHIC = "psychic"
     const val MECHANIC_WOLF = "mechanic_wolf"
     const val DEMON_HUNTER = "demon_hunter"
+    const val HIDDEN_WOLF = "hidden_wolf"
 }

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/game/roles/impl/WolfRoles.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/game/roles/impl/WolfRoles.kt
@@ -33,7 +33,7 @@ class WolfBeautyRole : BaseRole(
 @Component
 class WhiteWolfKingRole : BaseRole(
     RoleIds.WHITE_WOLF_KING, "role.white_wolf_king", Faction.WOLF,
-    setOf(RoleTag.WOLF_CHAT, RoleTag.DEATH_REVENGE),
+    setOf(RoleTag.WOLF_CHAT, RoleTag.DEATH_REVENGE, RoleTag.REVENGE_ON_SELF_DESTRUCT_ONLY),
 )
 
 @Component
@@ -48,10 +48,18 @@ class WolfYoungerRole : BaseRole(
     setOf(RoleTag.WOLF_CHAT),
 )
 
+/** 機械狼 — 互不相認 (no wolf chat); learns a role, and inherits the knife once the wolves are gone. */
 @Component
 class MechanicWolfRole : BaseRole(
     RoleIds.MECHANIC_WOLF, "role.mechanic_wolf", Faction.WOLF,
-    setOf(RoleTag.WOLF_CHAT),
+    setOf(RoleTag.INHERITS_KILL),
+)
+
+/** 隱狼 — 狼人陣營的平民: no wolf chat, reads as 好人, inherits the knife / dies with the team. */
+@Component
+class HiddenWolfRole : BaseRole(
+    RoleIds.HIDDEN_WOLF, "role.hidden_wolf", Faction.WOLF,
+    setOf(RoleTag.INVESTIGATED_AS_GOOD, RoleTag.INHERITS_KILL),
 )
 
 /** 夢魘 — nightmare. On the wolf chat team and acts at night, but per FEATURES §2's name rule
@@ -62,10 +70,11 @@ class NightmareRole : BaseRole(
     setOf(RoleTag.WOLF_CHAT),
 )
 
-/** 石像鬼 — gargoyle. Wolf faction by exception, but does not share wolf chat or the kill. */
+/** 石像鬼 — gargoyle. Wolf faction by exception, no wolf chat; inherits the knife once wolves are gone. */
 @Component
 class GargoyleRole : BaseRole(
     RoleIds.GARGOYLE, "role.gargoyle", Faction.WOLF,
+    setOf(RoleTag.INHERITS_KILL),
 )
 
 @Component

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/service/DayOrchestrator.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/service/DayOrchestrator.kt
@@ -1,0 +1,598 @@
+package dev.robothanzo.werewolf.service
+
+import dev.robothanzo.werewolf.discord.ButtonStyle
+import dev.robothanzo.werewolf.discord.CourtButton
+import dev.robothanzo.werewolf.discord.DiscordGateway
+import dev.robothanzo.werewolf.discord.DiscordInteractionHandler
+import dev.robothanzo.werewolf.discord.InteractionIds
+import dev.robothanzo.werewolf.discord.InteractionReply
+import dev.robothanzo.werewolf.discord.NicknameService
+import dev.robothanzo.werewolf.discord.SoundCue
+import dev.robothanzo.werewolf.domain.Faction
+import dev.robothanzo.werewolf.domain.GameSession
+import dev.robothanzo.werewolf.domain.LogSeverity
+import dev.robothanzo.werewolf.domain.Phase
+import dev.robothanzo.werewolf.domain.Seat
+import dev.robothanzo.werewolf.game.GameConstants
+import dev.robothanzo.werewolf.game.day.DuelResolver
+import dev.robothanzo.werewolf.game.flow.GameScheduler
+import dev.robothanzo.werewolf.game.roles.RoleIds
+import dev.robothanzo.werewolf.game.roles.RoleRegistry
+import dev.robothanzo.werewolf.game.speech.SpeechDirection
+import dev.robothanzo.werewolf.game.speech.SpeechFlow
+import dev.robothanzo.werewolf.game.speech.SpeechService
+import dev.robothanzo.werewolf.game.vote.Poll
+import dev.robothanzo.werewolf.game.vote.PollEngine
+import dev.robothanzo.werewolf.game.vote.PollKind
+import dev.robothanzo.werewolf.game.vote.PollOutcome
+import dev.robothanzo.werewolf.game.vote.PollStage
+import dev.robothanzo.werewolf.game.win.WinConditionChecker
+import dev.robothanzo.werewolf.i18n.Msg
+import jakarta.annotation.PostConstruct
+import org.springframework.stereotype.Service
+import kotlin.random.Random
+
+/**
+ * Runs the day-side loop on Discord, the mirror image of [NightOrchestrator]: it reacts to each
+ * day-phase entry, posts court announcements / audio cues / interactive prompts, persists the flow
+ * on [GameSession.speech] / [GameSession.poll], and routes the resulting button clicks back in. All
+ * sequencing/tally rules live in the pure [SpeechService] / [PollEngine]; this class is wiring +
+ * persistence only.
+ *
+ * State changes happen in single `mutate` blocks; the internal `*Internal` helpers operate on the
+ * already-loaded session (so they never nest a second `mutate`) and own the Discord/scheduler side
+ * effects. Scheduler deadlines and dashboard control endpoints call back into the public methods,
+ * each of which wraps exactly one `mutate`.
+ */
+@Service
+class DayOrchestrator(
+    private val sessionService: GameSessionService,
+    private val speeches: SpeechService,
+    private val polls: PollEngine,
+    private val win: WinConditionChecker,
+    private val roles: RoleRegistry,
+    private val nicknames: NicknameService,
+    private val gateway: DiscordGateway,
+    private val scheduler: GameScheduler,
+    private val announcer: CourtAnnouncer,
+    private val router: InteractionRouter,
+    private val msg: Msg,
+    private val deaths: DeathService,
+    private val duel: DuelResolver,
+) : DiscordInteractionHandler {
+
+    @PostConstruct
+    fun register() = router.register(InteractionIds.NS_DAY, this)
+
+    // ======================= phase entry points (from GameController dispatch) =======================
+
+    /** 天亮：morning cue, unmute, announce the night's deaths (or 平安夜), then run last words. */
+    fun enterDawn(guildId: Long) = sessionService.mutate(guildId) { enterDawnInternal(it) }
+
+    /** Start the daytime speech round; if there is a police badge the holder picks the direction. */
+    fun startSpeeches(guildId: Long) = sessionService.mutate(guildId) { startSpeechesInternal(it) }
+
+    /** Start the day-1 police election at its enrollment stage. */
+    fun startPoliceElection(guildId: Long) = sessionService.mutate(guildId) { startPoliceElectionInternal(it) }
+
+    /** Open the expel vote over all living seats. */
+    fun startExpelVote(guildId: Long) = sessionService.mutate(guildId) { startExpelVoteInternal(it) }
+
+    // ======================= dashboard control endpoints (DayController) =======================
+
+    fun skipCurrentSpeaker(guildId: Long) = sessionService.mutate(guildId) { advanceSpeakerInternal(it) }
+
+    fun stopSpeech(guildId: Long) = sessionService.mutate(guildId) { endSpeechInternal(it) }
+
+    fun chooseDirection(guildId: Long, direction: SpeechDirection) =
+        sessionService.mutate(guildId) { chooseDirectionInternal(it, direction) }
+
+    /** Force the current poll stage to resolve / advance early (same op the scheduler deadline runs). */
+    fun resolvePollStage(guildId: Long) = sessionService.mutate(guildId) { resolvePollStageInternal(it) }
+
+    // ======================= day-phase role actions (ROLES.md) =======================
+
+    /** 騎士 決鬥. Returns true when the duel hit a wolf and the game must enter night. */
+    fun knightDuel(guildId: Long, knightSeat: Int, targetSeat: Int): Boolean =
+        sessionService.mutate(guildId) { knightDuelInternal(it, knightSeat, targetSeat) }
+
+    /** 自爆 (狼人 / 白狼王 / 血月使徒). Returns true when the game must enter night (always, unless the
+     *  game just ended). */
+    fun selfDestruct(guildId: Long, seat: Int): Boolean =
+        sessionService.mutate(guildId) { selfDestructInternal(it, seat) }
+
+    private fun knightDuelInternal(session: GameSession, knightSeat: Int, targetSeat: Int): Boolean {
+        val knight = session.seat(knightSeat) ?: return false
+        val card = knight.cards.firstOrNull { !it.dead && it.roleId == RoleIds.KNIGHT } ?: return false
+        if (knight.duelUsed) return false
+        knight.duelUsed = true
+
+        val result = duel.resolve(session, knightSeat, targetSeat)
+        // 決鬥死亡的狼王/白狼王/狼美人技能不能發動 → the duel death suppresses revenge (KNIGHT_DUEL cause
+        // also spares a 狼美人's charmed seat inside DeathService).
+        val produced = deaths.killSeat(session, result.deadSeat, DeathCause.KNIGHT_DUEL, suppressRevenge = true)
+        if (result.targetIsWolf) {
+            announcer.announce(session.guildId, "day.duel.win", pad(knightSeat), pad(targetSeat))
+            sessionService.log(session.guildId, LogSeverity.ALERT, "day.duel.win", pad(knightSeat), pad(targetSeat))
+        } else {
+            announcer.announce(session.guildId, "day.duel.lose", pad(knightSeat), pad(targetSeat))
+            sessionService.log(session.guildId, LogSeverity.ALERT, "day.duel.lose", pad(knightSeat), pad(targetSeat))
+        }
+        announceDeaths(session, produced)
+        checkWinInternal(session)
+        if (session.phase == Phase.OVER) return false
+        // A wolf hit ends the day immediately; a miss lets the speeches continue.
+        if (result.targetIsWolf) { endSpeechInternal(session); enterNightInternal(session); return true }
+        return false
+    }
+
+    private fun selfDestructInternal(session: GameSession, seat: Int): Boolean {
+        val s = session.seat(seat) ?: return false
+        val card = s.cards.firstOrNull { !it.dead } ?: return false
+        // 狼美人不能自爆 (ROLES.md 狼美人).
+        if (card.roleId == RoleIds.WOLF_BEAUTY) return false
+
+        announcer.announce(session.guildId, "day.self_destruct", pad(seat))
+        sessionService.log(session.guildId, LogSeverity.ALERT, "day.self_destruct", pad(seat))
+
+        val isWhiteKing = card.roleId == RoleIds.WHITE_WOLF_KING
+        // 白狼王 只有自爆可帶人 → arm via SELF_DESTRUCT; every other 自爆 suppresses the shot.
+        val produced = deaths.applyDeath(session, seat, card, DeathCause.SELF_DESTRUCT, suppressRevenge = !isWhiteKing)
+        announceDeaths(session, produced)
+
+        // 血月使徒 自爆 seals the coming night (神職技能封印 + 不能指刀).
+        if (card.roleId == RoleIds.BLOOD_MOON) session.bloodMoonSeal = true
+
+        endSpeechInternal(session)
+        clearPollInternal(session)
+        checkWinInternal(session)
+        if (session.phase == Phase.OVER) return false
+        enterNightInternal(session)
+        return true
+    }
+
+    /** Announce every death the shared applier produced (the primary death plus any 殉情 cascade). */
+    private fun announceDeaths(session: GameSession, produced: List<DeathInfo>) {
+        produced.forEach { d ->
+            val padded = session.seat(d.seat)?.paddedNumber ?: pad(d.seat)
+            announcer.announce(session.guildId, "death.announce", padded, roles.localizedName(d.roleId))
+            sessionService.log(session.guildId, LogSeverity.ALERT, "death.announce", padded, roles.localizedName(d.roleId))
+        }
+    }
+
+    /** Set the phase to night; the caller (GameController) runs `night.startNight` after the mutate. */
+    private fun enterNightInternal(session: GameSession) {
+        session.phase = Phase.NIGHT
+    }
+
+    // ======================= scheduler callbacks =======================
+
+    private fun advanceSpeaker(guildId: Long) = sessionService.mutate(guildId) { advanceSpeakerInternal(it) }
+
+    // ======================= speech flow =======================
+
+    private fun startSpeechesInternal(session: GameSession) {
+        val alive = session.aliveSeats().map { it.number }
+        if (alive.isEmpty()) return
+        val police = session.policeSeat?.takeIf { session.seat(it)?.alive == true }
+        if (police != null) {
+            // Park on the direction choice and let the badge-holder pick (court buttons or dashboard).
+            session.speech = SpeechFlow(order = emptyList(), direction = SpeechDirection.DOWN, from = police, waiting = true)
+            session.stepEndsAt = null
+            announcer.announce(session.guildId, "speech.start")
+            gateway.sendCourtButtons(
+                session.guildId, msg.msg("police.dir.prompt"),
+                listOf(
+                    CourtButton("${InteractionIds.POLICE_DIR}:UP", msg.msg("speech.direction.up"), ButtonStyle.PRIMARY),
+                    CourtButton("${InteractionIds.POLICE_DIR}:DOWN", msg.msg("speech.direction.down"), ButtonStyle.PRIMARY),
+                ),
+            )
+        } else {
+            val from = alive.first()
+            val dir = if (Random.nextBoolean()) SpeechDirection.UP else SpeechDirection.DOWN
+            announcer.announce(session.guildId, "speech.start")
+            startSpeechFlowInternal(session, speeches.buildOrder(alive, from, dir), from, dir)
+        }
+    }
+
+    private fun chooseDirectionInternal(session: GameSession, direction: SpeechDirection) {
+        val flow = session.speech ?: return
+        if (!flow.waiting) return
+        val alive = session.aliveSeats().map { it.number }
+        startSpeechFlowInternal(session, speeches.buildOrder(alive, flow.from, direction), flow.from, direction)
+    }
+
+    private fun startSpeechFlowInternal(
+        session: GameSession,
+        order: List<Int>,
+        from: Int,
+        direction: SpeechDirection,
+        lastWords: Boolean = false,
+    ) {
+        if (order.isEmpty()) {
+            endSpeechInternal(session)
+            return
+        }
+        session.speech = SpeechFlow(order = order, direction = direction, from = from, lastWords = lastWords)
+        if (!lastWords) {
+            announcer.announce(session.guildId, "speech.direction", directionLabel(direction), pad(from))
+        }
+        promptSpeakerInternal(session)
+    }
+
+    private fun promptSpeakerInternal(session: GameSession) {
+        val flow = session.speech ?: return
+        val speaker = speeches.current(flow)
+        if (speaker == null) {
+            endSpeechInternal(session)
+            return
+        }
+        val seat = session.seat(speaker)
+        val endsAt = System.currentTimeMillis() + GameConstants.SPEECH_SECONDS * 1000L
+        flow.endsAt = endsAt
+        session.stepEndsAt = endsAt
+
+        if (session.settings.muteAfterSpeech) {
+            gateway.muteAll(session.guildId)
+            seat?.memberId?.let { gateway.muteMember(session.guildId, it, false) }
+        }
+
+        val text = msg.msg(if (flow.lastWords) "speech.last_words" else "speech.speaking", pad(speaker))
+        val buttons = buildList {
+            add(CourtButton(InteractionIds.SPEECH_SKIP, msg.msg("speech.skip.button"), ButtonStyle.SECONDARY))
+            if (!flow.lastWords) add(CourtButton(InteractionIds.SPEECH_INTERRUPT, msg.msg("speech.interrupt.button"), ButtonStyle.DANGER))
+        }
+        gateway.sendCourtButtons(session.guildId, text, buttons)
+        scheduler.schedule(session.guildId, GameScheduler.SPEECH, GameConstants.SPEECH_SECONDS * 1000L) {
+            advanceSpeaker(session.guildId)
+        }
+    }
+
+    private fun advanceSpeakerInternal(session: GameSession) {
+        val flow = session.speech ?: return
+        speeches.advance(flow)
+        if (speeches.isComplete(flow)) endSpeechInternal(session) else promptSpeakerInternal(session)
+    }
+
+    private fun endSpeechInternal(session: GameSession) {
+        if (session.speech == null) return
+        session.speech = null
+        session.stepEndsAt = null
+        scheduler.cancel(session.guildId, GameScheduler.SPEECH)
+        // The police campaign couples its speeches to the poll: when campaign speeches finish, the
+        // poll advances out of CAMPAIGN.
+        if (session.poll?.stage == PollStage.CAMPAIGN) resolvePollStageInternal(session)
+    }
+
+    // ======================= last words =======================
+
+    private fun startLastWordsInternal(session: GameSession, seats: List<Int>) {
+        val order = seats.filter { session.seat(it) != null }
+        if (order.isEmpty()) return
+        session.speech = SpeechFlow(order = order, direction = SpeechDirection.DOWN, from = order.first(), lastWords = true)
+        promptSpeakerInternal(session)
+    }
+
+    // ======================= dawn =======================
+
+    private fun enterDawnInternal(session: GameSession) {
+        gateway.unmuteAll(session.guildId)
+        gateway.playSound(session.guildId, SoundCue.MORNING)
+        announcer.announce(session.guildId, "game.day.start", session.day)
+
+        val deaths = session.nightState.deaths.toList()
+        if (deaths.isEmpty()) {
+            announcer.announce(session.guildId, "night.peaceful")
+        } else {
+            deaths.forEach { n ->
+                val seat = session.seat(n)
+                val roleName = seat?.cards?.lastOrNull { it.dead }?.let { roles.localizedName(it.roleId) } ?: ""
+                announcer.announce(session.guildId, "death.announce", pad(n), roleName)
+            }
+            startLastWordsInternal(session, deaths)
+        }
+    }
+
+    // ======================= polls (police election + expel) =======================
+
+    private fun startPoliceElectionInternal(session: GameSession) {
+        val poll = Poll(kind = PollKind.POLICE, stage = PollStage.ENROLL)
+        session.poll = poll
+        gateway.playSound(session.guildId, SoundCue.POLICE_ENROLL_START)
+        gateway.sendCourtButtons(
+            session.guildId, msg.msg("police.enroll.start"),
+            listOf(CourtButton(InteractionIds.POLICE_ENROLL, msg.msg("police.enroll.button"), ButtonStyle.SUCCESS)),
+        )
+        scheduleStage(session, GameConstants.POLICE_ENROLL_SECONDS, SoundCue.ENROLL_TEN_SECONDS)
+    }
+
+    private fun startExpelVoteInternal(session: GameSession) {
+        val poll = Poll(kind = PollKind.EXPEL, stage = PollStage.VOTING)
+        poll.candidates.addAll(session.aliveSeats().map { it.number })
+        session.poll = poll
+        beginVotingInternal(session)
+    }
+
+    /** Open (or re-open, for a PK runoff) the voting stage for the current poll. */
+    private fun beginVotingInternal(session: GameSession) {
+        val poll = session.poll ?: return
+        poll.stage = PollStage.VOTING
+        val police = poll.kind == PollKind.POLICE
+        if (police) {
+            gateway.playSound(session.guildId, SoundCue.POLICE_VOTE_START)
+        } else {
+            gateway.playSound(session.guildId, SoundCue.EXPEL_POLL_START)
+        }
+        val prefix = if (police) InteractionIds.POLICE_VOTE else InteractionIds.EXPEL_VOTE
+        val buttons = poll.activeCandidates().sorted()
+            .map { CourtButton("$prefix:$it", msg.msg("seat.name", pad(it)), ButtonStyle.PRIMARY) }
+        gateway.sendCourtButtons(session.guildId, msg.msg(if (police) "police.vote.start" else "expel.start"), buttons)
+        val seconds = if (police) GameConstants.POLICE_VOTE_SECONDS else GameConstants.EXPEL_VOTE_SECONDS
+        scheduleStage(session, seconds, SoundCue.POLL_TEN_SECONDS)
+    }
+
+    /** The poll-stage state machine — run on the stage deadline or a force-resolve. */
+    private fun resolvePollStageInternal(session: GameSession) {
+        val poll = session.poll ?: return
+        scheduler.cancel(session.guildId, GameScheduler.POLL_STAGE)
+        scheduler.cancel(session.guildId, GameScheduler.TEN_SECOND_WARNING)
+        val ctx = SessionPollContext(session)
+        when (poll.stage) {
+            PollStage.ENROLL -> {
+                val res = polls.resolveEnrollment(poll)
+                when (res.outcome) {
+                    PollOutcome.BADGE_DESTROYED -> { announcer.announce(session.guildId, "police.no_candidates"); clearPollInternal(session) }
+                    PollOutcome.ELECTED -> electPoliceInternal(session, res.winner!!, votes = null)
+                    else -> startCampaignInternal(session) // PK_NEEDED: ≥2 candidates campaign then vote
+                }
+            }
+            PollStage.CAMPAIGN -> beginWithdrawInternal(session)
+            PollStage.WITHDRAW -> {
+                val active = poll.activeCandidates()
+                when (active.size) {
+                    0 -> { announcer.announce(session.guildId, "police.destroyed"); clearPollInternal(session) }
+                    1 -> electPoliceInternal(session, active.first(), votes = null)
+                    else -> beginVotingInternal(session)
+                }
+            }
+            PollStage.VOTING -> resolveVotesInternal(session, ctx)
+            PollStage.RESOLVED -> {}
+        }
+    }
+
+    private fun startCampaignInternal(session: GameSession) {
+        val poll = session.poll ?: return
+        poll.stage = PollStage.CAMPAIGN
+        val candidates = poll.activeCandidates().sorted()
+        announcer.announce(session.guildId, "speech.start")
+        startSpeechFlowInternal(session, speeches.buildOrder(candidates, candidates.first(), SpeechDirection.DOWN), candidates.first(), SpeechDirection.DOWN)
+    }
+
+    private fun beginWithdrawInternal(session: GameSession) {
+        val poll = session.poll ?: return
+        poll.stage = PollStage.WITHDRAW
+        gateway.sendCourtButtons(
+            session.guildId, msg.msg("police.withdraw.prompt"),
+            listOf(CourtButton(InteractionIds.POLICE_WITHDRAW, msg.msg("police.withdraw.button"), ButtonStyle.DANGER)),
+        )
+        scheduleStage(session, GameConstants.POLICE_WITHDRAW_SECONDS, null)
+    }
+
+    private fun resolveVotesInternal(session: GameSession, ctx: SessionPollContext) {
+        val poll = session.poll ?: return
+        val res = polls.resolveVotes(poll, ctx)
+        when (res.outcome) {
+            PollOutcome.ELECTED -> electPoliceInternal(session, res.winner!!, votes = res.tally[res.winner])
+            PollOutcome.EXPELLED -> expelInternal(session, res.winner!!, votes = res.tally[res.winner])
+            PollOutcome.PK_NEEDED -> {
+                if (poll.kind == PollKind.EXPEL) announcer.announce(session.guildId, "expel.tie")
+                polls.startPkRound(poll, res.tied)
+                beginVotingInternal(session)
+            }
+            PollOutcome.BADGE_DESTROYED -> { announcer.announce(session.guildId, "police.destroyed"); clearPollInternal(session) }
+            PollOutcome.NO_RESULT -> {
+                if (poll.kind == PollKind.POLICE) announcer.announce(session.guildId, "police.destroyed")
+                else announcer.announce(session.guildId, "expel.no_expel")
+                clearPollInternal(session)
+            }
+        }
+    }
+
+    private fun electPoliceInternal(session: GameSession, seat: Int, votes: Double?) {
+        session.seats.forEach { it.police = false }
+        session.seat(seat)?.let { it.police = true; syncNickname(session, it) }
+        session.policeSeat = seat
+        if (votes == null) {
+            announcer.announce(session.guildId, "police.auto_elected", pad(seat))
+        } else {
+            announcer.announce(session.guildId, "police.elected", pad(seat), fmtVotes(votes))
+        }
+        sessionService.log(session.guildId, LogSeverity.ACTION, "police.elected", pad(seat), fmtVotes(votes ?: 0.0))
+        clearPollInternal(session)
+    }
+
+    private fun expelInternal(session: GameSession, seat: Int, votes: Double?) {
+        val seatObj = session.seat(seat)
+        announcer.announce(session.guildId, "expel.result", pad(seat), fmtVotes(votes ?: 0.0))
+        clearPollInternal(session)
+
+        // 白癡 翻牌免疫放逐: an unrevealed 白癡 survives the expel but loses its future vote.
+        if (seatObj != null && seatObj.idiot && !seatObj.idiotRevealed && seatObj.alive) {
+            seatObj.idiotRevealed = true
+            syncNickname(session, seatObj)
+            announcer.announce(session.guildId, "day.idiot.revealed", pad(seat))
+            sessionService.log(session.guildId, LogSeverity.INFO, "day.idiot.revealed", pad(seat))
+            return
+        }
+
+        // 血月使徒 被動: the last wolf to be expelled survives the vote once and gets a night kill.
+        val card0 = seatObj?.cards?.firstOrNull { !it.dead }
+        if (seatObj != null && card0?.roleId == RoleIds.BLOOD_MOON && !seatObj.bloodMoonRevived && isLastWolf(session, seat)) {
+            seatObj.bloodMoonRevived = true
+            announcer.announce(session.guildId, "day.blood_moon.survive", pad(seat))
+            sessionService.log(session.guildId, LogSeverity.ALERT, "day.blood_moon.survive", pad(seat))
+            return
+        }
+
+        // A real expel: apply the death through the shared applier (arms 狼王 revenge, cascades 殉情),
+        // and record the seat for the 守墓人 (ROLES.md 守墓人 第二晚起得知放逐者陣營).
+        session.lastExpelledSeat = seat
+        val card = seatObj?.cards?.firstOrNull { !it.dead }
+        if (card != null) {
+            deaths.applyDeath(session, seat, card, DeathCause.EXPEL).forEach { info ->
+                val padded = session.seat(info.seat)?.paddedNumber ?: pad(info.seat)
+                announcer.announce(session.guildId, "death.announce", padded, roles.localizedName(info.roleId))
+                sessionService.log(session.guildId, LogSeverity.ALERT, "death.announce", padded, roles.localizedName(info.roleId))
+            }
+        }
+        checkWinInternal(session)
+        if (session.phase != Phase.OVER) startLastWordsInternal(session, listOf(seat))
+    }
+
+    private fun clearPollInternal(session: GameSession) {
+        session.poll = null
+        session.stepEndsAt = null
+        scheduler.cancel(session.guildId, GameScheduler.POLL_STAGE)
+        scheduler.cancel(session.guildId, GameScheduler.TEN_SECOND_WARNING)
+    }
+
+    private fun scheduleStage(session: GameSession, seconds: Int, warnCue: SoundCue?) {
+        val poll = session.poll ?: return
+        val endsAt = System.currentTimeMillis() + seconds * 1000L
+        poll.stageEndsAt = endsAt
+        session.stepEndsAt = endsAt
+        val guildId = session.guildId
+        scheduler.schedule(guildId, GameScheduler.POLL_STAGE, seconds * 1000L) { resolvePollStage(guildId) }
+        val warnAt = seconds - GameConstants.TEN_SECONDS_WARNING_AT
+        if (warnCue != null && warnAt > 0) {
+            scheduler.schedule(guildId, GameScheduler.TEN_SECOND_WARNING, warnAt * 1000L) {
+                gateway.playSound(guildId, warnCue)
+            }
+        }
+    }
+
+    // ======================= interactions =======================
+
+    override fun handle(guildId: Long, userId: Long, customId: String, values: List<String>): InteractionReply? {
+        val session = sessionService.find(guildId) ?: return null
+        val seat = session.seats.firstOrNull { it.memberId == userId }?.number
+            ?: return InteractionReply("你不是這場遊戲的玩家")
+
+        var reply = "已收到"
+        sessionService.mutate(guildId) { s ->
+            val ctx = SessionPollContext(s)
+            when {
+                customId.startsWith(InteractionIds.SPEECH_SKIP) -> {
+                    val flow = s.speech
+                    when {
+                        flow == null -> reply = "目前沒有發言流程"
+                        speeches.current(flow) != seat -> reply = ":x: 你不是發言者"
+                        else -> { reply = "已跳過發言"; advanceSpeakerInternal(s) }
+                    }
+                }
+
+                customId.startsWith(InteractionIds.SPEECH_INTERRUPT) -> {
+                    val flow = s.speech
+                    when {
+                        flow == null || flow.lastWords -> reply = "目前無法投票"
+                        speeches.current(flow) == seat -> reply = ":x: 若要結束發言請按跳過"
+                        else -> {
+                            val speaker = speeches.current(flow)
+                            val carried = speeches.registerInterrupt(flow, seat, s.aliveSeats().size)
+                            if (carried) {
+                                announcer.announce(guildId, "speech.interrupted", pad(speaker ?: seat))
+                                reply = "下台投票通過"
+                                advanceSpeakerInternal(s)
+                            } else {
+                                reply = "已投下台票"
+                            }
+                        }
+                    }
+                }
+
+                customId.startsWith(InteractionIds.POLICE_DIR) -> {
+                    val flow = s.speech
+                    if (flow?.waiting == true && seat == s.policeSeat) {
+                        val dir = if (customId.endsWith("UP")) SpeechDirection.UP else SpeechDirection.DOWN
+                        chooseDirectionInternal(s, dir)
+                        reply = "已選擇發言方向"
+                    } else {
+                        reply = ":x: 現在無法選擇方向"
+                    }
+                }
+
+                customId.startsWith(InteractionIds.POLICE_ENROLL) -> {
+                    val poll = s.poll
+                    if (poll == null || poll.kind != PollKind.POLICE) {
+                        reply = "目前沒有警長競選"
+                    } else if (polls.enroll(poll, seat)) {
+                        reply = if (seat in poll.candidates) msg.msg("police.enrolled", pad(seat)) else "已取消參選"
+                    } else {
+                        reply = ":x: 現在無法參選"
+                    }
+                }
+
+                customId.startsWith(InteractionIds.POLICE_WITHDRAW) -> {
+                    val poll = s.poll
+                    reply = if (poll != null && polls.withdraw(poll, seat)) msg.msg("police.withdrew", pad(seat))
+                    else ":x: 現在無法退選"
+                }
+
+                customId.startsWith(InteractionIds.POLICE_VOTE) || customId.startsWith(InteractionIds.EXPEL_VOTE) -> {
+                    val poll = s.poll
+                    val candidate = customId.substringAfterLast(":").toIntOrNull()
+                    if (poll != null && candidate != null && polls.castVote(poll, ctx, seat, candidate)) {
+                        reply = msg.msg("seat.name", pad(candidate))
+                        if (votingComplete(s, ctx)) resolvePollStageInternal(s)
+                    } else {
+                        reply = ":x: 投票失敗"
+                    }
+                }
+            }
+        }
+        return InteractionReply(reply)
+    }
+
+    /** True once every eligible voter has cast a ballot, so the vote can resolve before the deadline. */
+    private fun votingComplete(session: GameSession, ctx: SessionPollContext): Boolean {
+        val poll = session.poll ?: return false
+        if (poll.stage != PollStage.VOTING) return false
+        val eligible = session.aliveSeats().map { it.number }.filter { polls.canVote(poll, ctx, it) }
+        return eligible.isNotEmpty() && eligible.all { poll.votes.containsKey(it) }
+    }
+
+    // ======================= helpers =======================
+
+    /** True when [seat] is the only living wolf-faction identity left on the board. */
+    private fun isLastWolf(session: GameSession, seat: Int): Boolean =
+        session.aliveSeats().none { s ->
+            s.number != seat && s.livingCards().any { roles.factionOf(it.roleId) == Faction.WOLF }
+        }
+
+    private fun checkWinInternal(session: GameSession) {
+        val result = win.check(session)
+        if (result.over) {
+            session.phase = Phase.OVER
+            sessionService.log(
+                session.guildId, LogSeverity.ALERT,
+                if (result.winner == Faction.WOLF) "game.over.wolf" else "game.over.good",
+            )
+            announcer.announce(session.guildId, if (result.winner == Faction.WOLF) "game.over.wolf" else "game.over.good")
+        }
+    }
+
+    private fun syncNickname(session: GameSession, seat: Seat) {
+        val memberId = seat.memberId ?: return
+        if (!gateway.canInteract(session.guildId, memberId)) return
+        gateway.setNickname(session.guildId, memberId, nicknames.nicknameFor(seat))
+    }
+
+    private fun directionLabel(direction: SpeechDirection): String =
+        msg.msg(if (direction == SpeechDirection.UP) "speech.direction.up" else "speech.direction.down")
+
+    private fun pad(seat: Int): String = seat.toString().padStart(2, '0')
+
+    /** Render a weighted tally without a trailing `.0` (3.0 → "3", 3.5 → "3.5"). */
+    private fun fmtVotes(votes: Double): String =
+        if (votes % 1.0 == 0.0) votes.toInt().toString() else votes.toString()
+}

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/service/DeathService.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/service/DeathService.kt
@@ -1,0 +1,121 @@
+package dev.robothanzo.werewolf.service
+
+import dev.robothanzo.werewolf.discord.DiscordGateway
+import dev.robothanzo.werewolf.discord.NicknameService
+import dev.robothanzo.werewolf.domain.Faction
+import dev.robothanzo.werewolf.domain.GameSession
+import dev.robothanzo.werewolf.domain.IdentityCard
+import dev.robothanzo.werewolf.domain.Seat
+import dev.robothanzo.werewolf.game.roles.RoleIds
+import dev.robothanzo.werewolf.game.roles.RoleRegistry
+import dev.robothanzo.werewolf.game.roles.RoleTag
+import org.springframework.stereotype.Service
+
+/** Why a seat died — drives revenge arming and the 殉情 / 決鬥 interaction rules (ROLES.md). */
+enum class DeathCause {
+    NIGHT, POISON, EXPEL, KNIGHT_DUEL, SELF_DESTRUCT, JUDGE, LOVER, TEAM,
+}
+
+/** One applied death (a single identity card), returned so callers can log / announce / tally. */
+data class DeathInfo(val seat: Int, val roleId: String, val cause: DeathCause)
+
+/**
+ * The single place a death is applied, shared by [NightOrchestrator], [GameActionService], and
+ * [DayOrchestrator]. It marks the card dead and syncs the nickname, then runs the cross-cutting
+ * ROLES.md rules in one place:
+ *  - **death-revenge arming** (`DEATH_REVENGE`): 獵人 / 狼王 arm unless the death is suppressed
+ *    (毒殺 / 殉情 / 決鬥 / 自爆 for 狼王); 白狼王 (`REVENGE_ON_SELF_DESTRUCT_ONLY`) arms only via 自爆.
+ *  - **殉情 cascade** (`loverSeat` / 狼美人 `charmedSeat`): the bonded seat dies too, revenge
+ *    suppressed — except a 騎士 duel on the 狼美人 spares the charmed seat.
+ *  - **隱狼 auto-death**: with 隱狼繼承狼刀 off, a lone 隱狼 dies once no other wolf is left alive.
+ *
+ * Logging stays with the callers (which own the guild-scoped log + announcements); this returns the
+ * full list of deaths it produced so they can render them.
+ */
+@Service
+class DeathService(
+    private val roles: RoleRegistry,
+    private val nicknames: NicknameService,
+    private val gateway: DiscordGateway,
+) {
+
+    fun applyDeath(
+        session: GameSession,
+        seatNumber: Int,
+        card: IdentityCard,
+        cause: DeathCause,
+        suppressRevenge: Boolean = false,
+    ): List<DeathInfo> {
+        if (card.dead) return emptyList()
+        val seat = session.seat(seatNumber) ?: return emptyList()
+        card.dead = true
+        syncNickname(session, seat)
+        val out = mutableListOf(DeathInfo(seatNumber, card.roleId, cause))
+
+        armRevenge(seat, card, cause, suppressRevenge)
+        out += cascadeBonds(session, seat, cause)
+        out += hiddenWolfAutoDeath(session)
+        return out
+    }
+
+    /** Convenience: kill the first living identity of a seat (judge kill / expel / duel target). */
+    fun killSeat(
+        session: GameSession,
+        seatNumber: Int,
+        cause: DeathCause,
+        suppressRevenge: Boolean = false,
+    ): List<DeathInfo> {
+        val seat = session.seat(seatNumber) ?: return emptyList()
+        val card = seat.cards.firstOrNull { !it.dead } ?: return emptyList()
+        return applyDeath(session, seatNumber, card, cause, suppressRevenge)
+    }
+
+    private fun armRevenge(seat: Seat, card: IdentityCard, cause: DeathCause, suppressRevenge: Boolean) {
+        val role = roles.byId(card.roleId) ?: return
+        if (!role.hasTag(RoleTag.DEATH_REVENGE)) return
+        val arm = if (role.hasTag(RoleTag.REVENGE_ON_SELF_DESTRUCT_ONLY)) {
+            cause == DeathCause.SELF_DESTRUCT // 白狼王 — 只有自爆可帶人
+        } else {
+            !suppressRevenge // 獵人 / 狼王 — 毒殺 / 殉情 / 決鬥 / 自爆(狼王) suppress the shot
+        }
+        if (arm) seat.revengePending = true
+    }
+
+    /** 殉情: kill the lover / 魅惑 victim bonded to the seat that just died (revenge suppressed). */
+    private fun cascadeBonds(session: GameSession, seat: Seat, cause: DeathCause): List<DeathInfo> {
+        val out = mutableListOf<DeathInfo>()
+        val bonded = mutableSetOf<Int>()
+        seat.loverSeat?.let { bonded += it }
+        // 騎士 撞死狼美人 → 魅惑的人不會死 (ROLES.md 騎士 / 狼美人).
+        val charmExempt = cause == DeathCause.KNIGHT_DUEL && seat.cards.any { it.roleId == RoleIds.WOLF_BEAUTY }
+        if (!charmExempt) seat.charmedSeat?.let { bonded += it }
+        for (b in bonded) {
+            val bondedSeat = session.seat(b) ?: continue
+            if (!bondedSeat.alive) continue
+            out += killSeat(session, b, DeathCause.LOVER, suppressRevenge = true)
+        }
+        return out
+    }
+
+    /**
+     * 隱狼 與狼隊共享勝利條件但互不相認: with 隱狼繼承狼刀 off it dies the moment no other wolf is
+     * alive; with the setting on it survives as the last wolf and inherits the knife (Phase 6).
+     */
+    private fun hiddenWolfAutoDeath(session: GameSession): List<DeathInfo> {
+        if (session.settings.hiddenWolfInheritsKnife) return emptyList()
+        val hidden = session.aliveSeats().firstOrNull { s ->
+            s.livingCards().any { it.roleId == RoleIds.HIDDEN_WOLF }
+        } ?: return emptyList()
+        val otherWolfAlive = session.aliveSeats().any { s ->
+            s.number != hidden.number && s.livingCards().any { roles.factionOf(it.roleId) == Faction.WOLF }
+        }
+        if (otherWolfAlive) return emptyList()
+        return killSeat(session, hidden.number, DeathCause.TEAM, suppressRevenge = true)
+    }
+
+    private fun syncNickname(session: GameSession, seat: Seat) {
+        val memberId = seat.memberId ?: return
+        if (!gateway.canInteract(session.guildId, memberId)) return
+        gateway.setNickname(session.guildId, memberId, nicknames.nicknameFor(seat))
+    }
+}

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/service/GameActionService.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/service/GameActionService.kt
@@ -2,6 +2,7 @@ package dev.robothanzo.werewolf.service
 
 import dev.robothanzo.werewolf.discord.DiscordGateway
 import dev.robothanzo.werewolf.discord.NicknameService
+import dev.robothanzo.werewolf.domain.DashboardRole
 import dev.robothanzo.werewolf.domain.GameSession
 import dev.robothanzo.werewolf.domain.LogSeverity
 import dev.robothanzo.werewolf.domain.Phase
@@ -10,6 +11,7 @@ import dev.robothanzo.werewolf.game.assign.AssignmentService
 import dev.robothanzo.werewolf.game.roles.RoleRegistry
 import dev.robothanzo.werewolf.game.win.WinConditionChecker
 import dev.robothanzo.werewolf.game.flow.GameScheduler
+import dev.robothanzo.werewolf.security.DashboardRoleService
 import org.springframework.stereotype.Service
 import kotlin.random.Random
 
@@ -28,12 +30,14 @@ class GameActionService(
     private val gateway: DiscordGateway,
     private val discordOps: DiscordOpsService,
     private val gameScheduler: GameScheduler,
+    private val roleService: DashboardRoleService,
+    private val deaths: DeathService,
 ) {
 
     /** Deal identities to the eligible (non-bot, non-owner, non-spectator) members. */
     fun assign(guildId: Long) = sessionService.mutate(guildId) { session ->
         val eligible = gateway.listMembers(guildId)
-            .filter { !it.bot && !it.owner }
+            .filter { !it.bot && !it.owner && roleService.roleFor(guildId, it.id) != DashboardRole.JUDGE }
             .map { it.id }
             .ifEmpty { session.seats.mapNotNull { it.memberId } } // dev fallback to existing bindings
         assignment.assign(session, eligible, Random.Default)
@@ -46,19 +50,37 @@ class GameActionService(
         discordOps.applyAssignment(session)
     }
 
-    /** Mark one identity of a seat dead (soft death), then re-check win conditions. */
+    /** Mark one identity of a seat dead (soft death) through the shared [DeathService] — which arms
+     *  any 獵人 / 狼王 revenge and cascades 殉情 — then re-check win conditions. */
     fun kill(guildId: Long, seatNumber: Int, identityIndex: Int?, @Suppress("UNUSED_PARAMETER") lastWords: Boolean) =
         sessionService.mutate(guildId) { session ->
             val seat = session.seat(seatNumber) ?: error("seat $seatNumber not found")
             val idx = identityIndex ?: seat.cards.indexOfFirst { !it.dead }
             require(idx in seat.cards.indices) { "no living identity to kill" }
-            val card = seat.cards[idx]
-            card.dead = true
-            val roleName = roles.localizedName(card.roleId)
-            sessionService.log(guildId, LogSeverity.ALERT, "death.announce", seat.paddedNumber, roleName)
-            syncNickname(session, seat)
+            val produced = deaths.applyDeath(session, seatNumber, seat.cards[idx], DeathCause.JUDGE)
+            logDeaths(guildId, session, produced)
             checkWin(session)
         }
+
+    /** Fire an armed 獵人 / 狼王 / 白狼王 revenge shot at [targetSeat] (FEATURES §5, ROLES.md). */
+    fun revenge(guildId: Long, seatNumber: Int, targetSeat: Int) = sessionService.mutate(guildId) { session ->
+        val seat = session.seat(seatNumber) ?: error("seat $seatNumber not found")
+        require(seat.revengePending) { "seat $seatNumber has no pending revenge" }
+        seat.revengePending = false
+        // The shot itself is a normal death (so a 狼王 can chain its own 殉情); the target keeps its abilities.
+        val produced = deaths.killSeat(session, targetSeat, DeathCause.JUDGE)
+        sessionService.log(guildId, LogSeverity.ACTION, "day.revenge", seat.paddedNumber, String.format("%02d", targetSeat))
+        logDeaths(guildId, session, produced)
+        checkWin(session)
+    }
+
+    /** Announce every death the shared applier produced (the primary death plus any 殉情 cascade). */
+    private fun logDeaths(guildId: Long, session: GameSession, produced: List<DeathInfo>) {
+        produced.forEach { d ->
+            val paddedNumber = session.seat(d.seat)?.paddedNumber ?: String.format("%02d", d.seat)
+            sessionService.log(guildId, LogSeverity.ALERT, "death.announce", paddedNumber, roles.localizedName(d.roleId))
+        }
+    }
 
     /** Revive the whole seat or a single named identity. */
     fun revive(guildId: Long, seatNumber: Int, identityIndex: Int?) = sessionService.mutate(guildId) { session ->
@@ -122,6 +144,9 @@ class GameActionService(
         session.phase = Phase.LOBBY
         session.day = 0
         session.timerEndsAt = null
+        session.stepEndsAt = null
+        session.speech = null
+        session.poll = null
         sessionService.clearLogs(guildId)
         sessionService.log(guildId, LogSeverity.ACTION, "game.reset")
         gameScheduler.cancelAll(guildId)

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/service/NightOrchestrator.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/service/NightOrchestrator.kt
@@ -5,12 +5,14 @@ import dev.robothanzo.werewolf.discord.DiscordInteractionHandler
 import dev.robothanzo.werewolf.discord.InteractionIds
 import dev.robothanzo.werewolf.discord.InteractionReply
 import dev.robothanzo.werewolf.discord.SeatOption
+import dev.robothanzo.werewolf.discord.SoundCue
 import dev.robothanzo.werewolf.domain.Faction
 import dev.robothanzo.werewolf.domain.GameSession
 import dev.robothanzo.werewolf.domain.LogSeverity
 import dev.robothanzo.werewolf.domain.NightIntentData
 import dev.robothanzo.werewolf.domain.NightState
 import dev.robothanzo.werewolf.domain.Phase
+import dev.robothanzo.werewolf.domain.Seat
 import dev.robothanzo.werewolf.game.GameConstants
 import dev.robothanzo.werewolf.game.flow.GameScheduler
 import dev.robothanzo.werewolf.game.night.NightAbility
@@ -20,6 +22,7 @@ import dev.robothanzo.werewolf.game.night.NightResolver
 import dev.robothanzo.werewolf.game.night.Effect
 import dev.robothanzo.werewolf.game.roles.RoleIds
 import dev.robothanzo.werewolf.game.roles.RoleRegistry
+import dev.robothanzo.werewolf.game.roles.RoleTag
 import dev.robothanzo.werewolf.game.win.WinConditionChecker
 import dev.robothanzo.werewolf.i18n.Msg
 import jakarta.annotation.PostConstruct
@@ -47,6 +50,9 @@ class NightOrchestrator(
     private val gateway: DiscordGateway,
     private val scheduler: GameScheduler,
     private val msg: Msg,
+    private val announcer: CourtAnnouncer,
+    private val router: InteractionRouter,
+    private val deaths: DeathService,
 ) : DiscordInteractionHandler {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -54,13 +60,21 @@ class NightOrchestrator(
     private val abilitiesByRole = abilities.groupBy { it.roleId }
     private val wolfKillAbility = abilities.firstOrNull { Effect.WOLF_KILL in it.writes }
 
+    private companion object {
+        const val MECHANIC_LEARN_ID = "mechanic_wolf.learn"
+    }
+
     @PostConstruct
-    fun register() = gateway.setInteractionHandler(this)
+    fun register() = router.register(InteractionIds.NS_NIGHT, this)
 
     // ---------- starting a night ----------
     fun startNight(guildId: Long) {
         sessionService.mutate(guildId) { session -> planNight(session) }
         val session = sessionService.find(guildId) ?: return
+        // Court cue: night falls, everyone is silenced (the announcement itself was previously log-only).
+        gateway.muteAll(guildId)
+        gateway.playSound(guildId, SoundCue.NIGHT)
+        announcer.announce(guildId, "night.start", session.day)
         promptActors(session)
         val endsAt = session.nightState.endsAt
         scheduler.schedule(guildId, GameScheduler.NIGHT, endsAt - System.currentTimeMillis()) { resolveNight(guildId) }
@@ -69,15 +83,26 @@ class NightOrchestrator(
     private fun planNight(session: GameSession) {
         val alive = session.aliveSeats()
         val present = alive.flatMap { it.livingCards() }.map { it.roleId }.toSet()
-        val wolfParticipants = alive.filter { seat ->
-            seat.livingCards().any { roles.factionOf(it.roleId) == Faction.WOLF && it.roleId != RoleIds.GARGOYLE }
-        }.map { it.number }.toSet()
+        // 機械狼 acts as its learned identity once it has learned (ROLES.md 機械狼 主動技).
+        val learned = alive.mapNotNull { it.learnedRoleId }.toSet()
+        val mechanicMayLearn = alive.any { s ->
+            s.livingCards().any { it.roleId == RoleIds.MECHANIC_WOLF } && s.learnedRoleId == null
+        }
+
+        // 血月使徒 自爆 seals this one night: all 神職 abilities void + the wolves cannot knife.
+        val sealed = session.bloodMoonSeal
+        session.bloodMoonSeal = false
+
+        val wolfParticipants = if (sealed) emptySet() else wolfKillParticipants(session, alive)
 
         val active = abilitiesByRole.values.flatten()
             .filter { it.id != wolfKillAbility?.id }
-            .filter { it.roleId in present }
+            .filter { it.roleId in present || it.roleId in learned }
+            .filterNot { it.id == MECHANIC_LEARN_ID && !mechanicMayLearn } // one-shot learn
             .filterNot { it.firstNightOnly && session.day != 1 }
             .filterNot { it.id == "demon_hunter.hunt" && session.day <= 1 }
+            .filterNot { sealed && roles.factionOf(it.roleId) == Faction.GOD } // 封印神職技能
+            .distinctBy { it.id }
             .toMutableList()
         if (wolfParticipants.isNotEmpty()) wolfKillAbility?.let { active.add(it) }
 
@@ -94,6 +119,29 @@ class NightOrchestrator(
         sessionService.log(session.guildId, LogSeverity.ACTION, "night.start", session.day)
     }
 
+    /**
+     * Who opens their eyes for the wolf knife. Normally the chat wolves (wolf-faction roles that
+     * aren't a 互不相認 大哥). Once no chat wolf is left alive, an `INHERITS_KILL` seat (石像鬼 / 隱狼 /
+     * 機械狼) inherits the knife and is armed — 隱狼 only if 隱狼繼承狼刀 is enabled (ROLES.md).
+     */
+    private fun wolfKillParticipants(session: GameSession, alive: List<Seat>): Set<Int> {
+        fun inheritor(roleId: String) = roles.byId(roleId)?.hasTag(RoleTag.INHERITS_KILL) == true
+        val chatWolves = alive.filter { seat ->
+            seat.livingCards().any { roles.factionOf(it.roleId) == Faction.WOLF && !inheritor(it.roleId) }
+        }
+        if (chatWolves.isNotEmpty()) return chatWolves.map { it.number }.toSet()
+
+        // No chat wolf left — the 大哥 inherits the knife.
+        val inheritors = alive.filter { seat ->
+            seat.livingCards().any { card ->
+                inheritor(card.roleId) &&
+                    (card.roleId != RoleIds.HIDDEN_WOLF || session.settings.hiddenWolfInheritsKnife)
+            }
+        }
+        inheritors.forEach { it.knifeArmed = true }
+        return inheritors.map { it.number }.toSet()
+    }
+
     private fun promptActors(session: GameSession) {
         val guildId = session.guildId
         val options = session.aliveSeats().map { SeatOption(it.number, "玩家${it.paddedNumber}") }
@@ -103,7 +151,11 @@ class NightOrchestrator(
                 return@forEach
             }
             val ability = abilitiesById[abilityId] ?: return@forEach
-            val actors = session.aliveSeats().filter { seat -> seat.livingCards().any { it.roleId == ability.roleId } }
+            // A 機械狼 that has learned a role also acts as that role (besides the real card-holders).
+            val actors = session.aliveSeats().filter { seat ->
+                seat.livingCards().any { it.roleId == ability.roleId } ||
+                    (ability.id != MECHANIC_LEARN_ID && seat.learnedRoleId == ability.roleId)
+            }
             val roleName = roles.localizedName(ability.roleId)
             val extras = if (ability.roleId == RoleIds.WITCH) listOf(InteractionIds.WITCH_SAVE to "解救今晚刀口") else emptyList()
             actors.forEach { actor ->
@@ -174,16 +226,25 @@ class NightOrchestrator(
             if (!night.active || night.resolved) return@mutate
 
             val resolution = resolver.resolve(declarations.build(night), session)
+            // Persist 狼美人 charm / 邱比特 lover bonds first so a same-night death can cascade 殉情.
+            persistBonds(session)
+            night.deaths.clear()
+            // Each death flows through the shared applier (arms 獵人/狼王 revenge, cascades 殉情,
+            // 隱狼 auto-death). The resolver's suppressRevenge flags are carried through.
             resolution.deaths.forEach { death ->
-                session.seat(death.seat)?.let { seat ->
-                    val card = seat.cards.firstOrNull { !it.dead }
-                    if (card != null) {
-                        card.dead = true
-                        sessionService.log(guildId, LogSeverity.ALERT, "night.death", seat.paddedNumber, roles.localizedName(card.roleId))
+                val seat = session.seat(death.seat) ?: return@forEach
+                val card = seat.cards.firstOrNull { !it.dead } ?: return@forEach
+                deaths.applyDeath(session, death.seat, card, DeathCause.NIGHT, death.suppressRevenge).forEach { info ->
+                    if (info.seat !in night.deaths) {
+                        night.deaths.add(info.seat)
+                        val padded = session.seat(info.seat)?.paddedNumber ?: ""
+                        sessionService.log(guildId, LogSeverity.ALERT, "night.death", padded, roles.localizedName(info.roleId))
                     }
                 }
             }
+            applyLearns(session)
             announceInvestigations(session)
+            deliverGravekeeper(session)
 
             val summary = if (resolution.deaths.isEmpty()) msg.msg("night.peaceful")
             else resolution.deaths.joinToString("、") { msg.msg("seat.name", session.seat(it.seat)?.paddedNumber ?: "") }
@@ -203,7 +264,56 @@ class NightOrchestrator(
         }
     }
 
-    /** DM each investigator the faction of the seat they checked. */
+    /** 守墓人 — from the second night on, DM the faction (好人/狼人) of the last expelled seat
+     *  (ROLES.md 守墓人: 第一晚無技能, 第二晚起). */
+    private fun deliverGravekeeper(session: GameSession) {
+        if (session.day < 2) return
+        val expelled = session.lastExpelledSeat?.let { session.seat(it) } ?: return
+        val keeper = session.aliveSeats().firstOrNull { s ->
+            s.livingCards().any { it.roleId == RoleIds.GRAVEKEEPER }
+        } ?: return
+        val card = expelled.cards.lastOrNull { it.dead } ?: expelled.cards.firstOrNull() ?: return
+        val faction = if (expelled.clone) Faction.GOD else roles.factionOf(card.roleId)
+        val verdict = if (faction == Faction.WOLF) "狼人" else "好人"
+        gateway.sendSeatMessage(session.guildId, keeper.number, msg.msg("gravekeeper.report", expelled.paddedNumber, verdict))
+    }
+
+    /** Persist 狼美人 charm + 邱比特 lover bonds onto the seats so a daytime death can cascade 殉情
+     *  (the in-resolver night 殉情 is unchanged; this only feeds the day-phase logic). */
+    private fun persistBonds(session: GameSession) {
+        session.nightState.intents.filter { !it.skipped }.forEach { intent ->
+            when (intent.abilityId) {
+                "wolf_beauty.charm" -> {
+                    val beauty = intent.actorSeats.firstOrNull() ?: return@forEach
+                    val victim = intent.targets.firstOrNull() ?: return@forEach
+                    session.seat(beauty)?.charmedSeat = victim
+                }
+                "cupid.bond" -> {
+                    if (intent.targets.size < 2) return@forEach
+                    val (a, b) = intent.targets[0] to intent.targets[1]
+                    session.seat(a)?.loverSeat = b
+                    session.seat(b)?.loverSeat = a
+                }
+            }
+        }
+    }
+
+    /** 機械狼 learn — copy the chosen seat's identity into the actor's learnedRoleId (one-shot). */
+    private fun applyLearns(session: GameSession) {
+        session.nightState.intents
+            .filter { it.abilityId == MECHANIC_LEARN_ID && !it.skipped && it.targets.isNotEmpty() }
+            .forEach { intent ->
+                val mechanic = intent.actorSeats.firstOrNull()?.let { session.seat(it) } ?: return@forEach
+                if (mechanic.learnedRoleId != null) return@forEach
+                val target = session.seat(intent.targets.first()) ?: return@forEach
+                val card = target.livingCards().firstOrNull() ?: target.cards.firstOrNull() ?: return@forEach
+                // Kept off the public log — the learned identity is secret, surfaced only on the dashboard.
+                mechanic.learnedRoleId = card.roleId
+            }
+    }
+
+    /** DM each investigator their result: 預言家 reports faction (隱狼 reads 好人); 通靈師/石像鬼 report
+     *  the exact identity (a 機械狼 reads as its learned identity). */
     private fun announceInvestigations(session: GameSession) {
         session.nightState.intents
             .filter { it.abilityId.endsWith("investigate") && !it.skipped && it.targets.isNotEmpty() }
@@ -211,8 +321,14 @@ class NightOrchestrator(
                 val actor = intent.actorSeats.firstOrNull() ?: return@forEach
                 val target = session.seat(intent.targets.first()) ?: return@forEach
                 val card = target.livingCards().firstOrNull() ?: target.cards.firstOrNull() ?: return@forEach
-                val faction = if (target.clone) Faction.GOD else roles.factionOf(card.roleId)
-                val verdict = if (faction == Faction.WOLF) "狼人" else "好人"
+                val verdict = if (intent.roleId == RoleIds.SEER) {
+                    val readsGood = roles.byId(card.roleId)?.hasTag(RoleTag.INVESTIGATED_AS_GOOD) == true
+                    val faction = if (target.clone) Faction.GOD else roles.factionOf(card.roleId)
+                    if (faction == Faction.WOLF && !readsGood) "狼人" else "好人"
+                } else {
+                    // 通靈師 / 石像鬼 — exact identity, following a 機械狼's learned id.
+                    roles.localizedName(target.learnedRoleId ?: card.roleId)
+                }
                 gateway.sendSeatMessage(session.guildId, actor, "查驗 玩家${target.paddedNumber} → $verdict")
             }
     }

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/service/SessionPollContext.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/service/SessionPollContext.kt
@@ -1,0 +1,22 @@
+package dev.robothanzo.werewolf.service
+
+import dev.robothanzo.werewolf.domain.GameSession
+import dev.robothanzo.werewolf.game.GameConstants
+import dev.robothanzo.werewolf.game.vote.PollContext
+
+/**
+ * Bridges a [GameSession] to the pure [PollContext] the [dev.robothanzo.werewolf.game.vote.PollEngine]
+ * needs — the police vote weight, liveness, and the dead-白癡 vote loss. Kept out of `game/vote` so
+ * that package stays free of the Mongo document.
+ */
+class SessionPollContext(private val session: GameSession) : PollContext {
+
+    override fun weightOf(seat: Int): Double =
+        if (seat == session.policeSeat) GameConstants.POLICE_VOTE_WEIGHT else 1.0
+
+    override fun isAlive(seat: Int): Boolean = session.seat(seat)?.alive == true
+
+    /** A 白癡 loses its vote once it has flipped its card on expel (ROLES.md 白癡), or once fully dead. */
+    override fun isDeadIdiot(seat: Int): Boolean =
+        session.seat(seat)?.let { it.idiot && (it.idiotRevealed || !it.alive) } == true
+}

--- a/backend/src/main/kotlin/dev/robothanzo/werewolf/service/SnapshotService.kt
+++ b/backend/src/main/kotlin/dev/robothanzo/werewolf/service/SnapshotService.kt
@@ -7,7 +7,10 @@ import dev.robothanzo.werewolf.controller.dto.LogDto
 import dev.robothanzo.werewolf.controller.dto.NightActionDto
 import dev.robothanzo.werewolf.controller.dto.NightDto
 import dev.robothanzo.werewolf.controller.dto.NightWaveDto
+import dev.robothanzo.werewolf.controller.dto.PollCandidateDto
+import dev.robothanzo.werewolf.controller.dto.PollDto
 import dev.robothanzo.werewolf.controller.dto.SeatDto
+import dev.robothanzo.werewolf.controller.dto.SpeechDto
 import dev.robothanzo.werewolf.controller.dto.WinnerDto
 import dev.robothanzo.werewolf.discord.DiscordGateway
 import dev.robothanzo.werewolf.domain.Faction
@@ -20,6 +23,7 @@ import dev.robothanzo.werewolf.game.night.Effect
 import dev.robothanzo.werewolf.game.night.NightAbility
 import dev.robothanzo.werewolf.game.night.NightDeclarationsBuilder
 import dev.robothanzo.werewolf.game.roles.RoleRegistry
+import dev.robothanzo.werewolf.game.vote.PollEngine
 import dev.robothanzo.werewolf.game.win.WinConditionChecker
 import dev.robothanzo.werewolf.i18n.Msg
 import org.springframework.stereotype.Service
@@ -36,6 +40,7 @@ class SnapshotService(
     private val gateway: DiscordGateway,
     private val msg: Msg,
     private val declarations: NightDeclarationsBuilder,
+    private val polls: PollEngine,
     abilities: List<NightAbility>,
 ) {
     private val abilitiesById = abilities.associateBy { it.id }
@@ -67,6 +72,12 @@ class SnapshotService(
                 clone = seat.clone,
                 idiot = seat.idiot,
                 orderLocked = seat.orderLocked,
+                revengePending = seat.revengePending,
+                idiotRevealed = seat.idiotRevealed,
+                loverSeat = seat.loverSeat,
+                charmedSeat = seat.charmedSeat,
+                learnedRoleId = seat.learnedRoleId,
+                knifeArmed = seat.knifeArmed,
             )
         }
 
@@ -80,6 +91,8 @@ class SnapshotService(
             started = session.phase != Phase.LOBBY,
             doubleIdentity = session.settings.doubleIdentity,
             muteAfterSpeech = session.settings.muteAfterSpeech,
+            witchSelfSave = session.settings.witchSelfSave,
+            hiddenWolfInheritsKnife = session.settings.hiddenWolfInheritsKnife,
             assigned = session.assigned,
             policeSeat = session.policeSeat,
             aliveCount = session.aliveSeats().size,
@@ -90,13 +103,55 @@ class SnapshotService(
             timerEndsAt = session.timerEndsAt,
             seats = seats,
             meters = meters(session),
-            speech = null,
-            poll = null,
+            speech = buildSpeech(session),
+            poll = buildPoll(session),
             night = buildNight(session),
             log = logs.map {
                 LogDto(it.id, it.timestamp.toEpochMilli(), it.severity.name.lowercase(), it.rendered)
             },
             pool = session.pool,
+        )
+    }
+
+    /** Live day speech flow (speaking order, current speaker, the parked direction choice). */
+    private fun buildSpeech(session: GameSession): SpeechDto? {
+        val flow = session.speech ?: return null
+        val speaker = flow.order.getOrNull(flow.index)
+        return SpeechDto(
+            active = true,
+            waiting = flow.waiting,
+            direction = flow.direction.name,
+            fromSeat = flow.from,
+            speakerSeat = speaker,
+            endsAt = flow.endsAt,
+            order = flow.order,
+            upcoming = if (flow.index + 1 <= flow.order.size) flow.order.drop(flow.index + 1) else emptyList(),
+        )
+    }
+
+    /** Live poll (police election or expel vote) with weighted tallies and per-candidate voters. */
+    private fun buildPoll(session: GameSession): PollDto? {
+        val poll = session.poll ?: return null
+        val ctx = SessionPollContext(session)
+        val tally = polls.tally(poll, ctx)
+        val voters = polls.voters(poll)
+        val display = if (poll.pkRound) poll.pkCandidates.sorted() else poll.candidates.sorted()
+        val candidates = display.map { seat ->
+            PollCandidateDto(
+                seat = seat,
+                withdrawn = seat in poll.withdrawn,
+                weight = tally[seat] ?: 0.0,
+                voters = voters[seat] ?: emptyList(),
+            )
+        }
+        val eligible = session.aliveSeats().map { it.number }.count { polls.canVote(poll, ctx, it) }
+        return PollDto(
+            kind = poll.kind.name,
+            stage = poll.stage.name,
+            endsAt = poll.stageEndsAt,
+            candidates = candidates,
+            eligibleVoters = if (poll.stage.name == "VOTING") eligible else session.aliveSeats().size,
+            votesCast = poll.votes.size,
         )
     }
 

--- a/backend/src/main/resources/i18n/messages_zh_TW.properties
+++ b/backend/src/main/resources/i18n/messages_zh_TW.properties
@@ -29,6 +29,7 @@ role.evil_knight=惡靈騎士
 role.psychic=通靈師
 role.mechanic_wolf=機械狼
 role.demon_hunter=獵魔人
+role.hidden_wolf=隱狼
 
 # ---- Factions ----
 faction.wolf=狼
@@ -78,6 +79,9 @@ police.transferred=警徽由 玩家{0} 移交給 玩家{1}
 police.destroyed=警徽撕毀
 police.button.transfer=移交
 police.button.destroy=撕毀
+police.dir.prompt=請警長選擇發言方向
+police.withdraw.prompt=退選階段開始，候選人可點擊退選
+police.withdraw.button=退選
 
 # ---- Expel poll ----
 expel.start=放逐投票開始
@@ -95,6 +99,8 @@ speech.ended=玩家{0} 發言結束
 speech.skipped=玩家{0} 發言被跳過
 speech.interrupted=玩家{0} 發言被打斷
 speech.last_words=玩家{0} 的遺言
+speech.skip.button=跳過
+speech.interrupt.button=下台
 
 # ---- Deaths / revival ----
 death.announce=玩家{0} 的「{1}」死亡
@@ -115,6 +121,15 @@ game.over.reason.parity=狼人達到屠邊人數
 game.over.reason.gbaby=所有金寶寶已出局
 game.reset=遊戲已重置
 game.day.start=第 {0} 天白天開始
+
+# ---- Day-phase role actions (ROLES.md) ----
+day.revenge=玩家{0} 發動技能，槍殺 玩家{1}
+day.duel.win=騎士 玩家{0} 決鬥 玩家{1}，命中狼人陣營
+day.duel.lose=騎士 玩家{0} 決鬥 玩家{1}，以死謝罪
+day.idiot.revealed=玩家{0} 翻開白癡牌，免疫本次放逐（往後失去投票權）
+day.self_destruct=玩家{0} 自爆
+day.blood_moon.survive=血月使徒 玩家{0} 為最後一狼，暫時存活並進入黑夜
+gravekeeper.report=守墓人查驗：昨日放逐的 玩家{0} → {1}
 
 # ---- Judge admin ----
 judge.promoted=玩家 {0} 已被任命為法官

--- a/backend/src/test/kotlin/dev/robothanzo/werewolf/game/day/DuelResolverTest.kt
+++ b/backend/src/test/kotlin/dev/robothanzo/werewolf/game/day/DuelResolverTest.kt
@@ -1,0 +1,37 @@
+package dev.robothanzo.werewolf.game.day
+
+import dev.robothanzo.werewolf.game.roles.RoleIds.KNIGHT
+import dev.robothanzo.werewolf.game.roles.RoleIds.VILLAGER
+import dev.robothanzo.werewolf.game.roles.RoleIds.WOLF
+import dev.robothanzo.werewolf.support.TestFixtures.registry
+import dev.robothanzo.werewolf.support.TestFixtures.seat
+import dev.robothanzo.werewolf.support.TestFixtures.session
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DuelResolverTest {
+
+    private val resolver = DuelResolver(registry())
+
+    private fun board() = session(seats = listOf(
+        seat(1, KNIGHT to false),
+        seat(2, WOLF to false),
+        seat(3, VILLAGER to false),
+    ))
+
+    @Test
+    fun `dueling a wolf kills the wolf`() {
+        val r = resolver.resolve(board(), knightSeat = 1, targetSeat = 2)
+        assertTrue(r.targetIsWolf)
+        assertEquals(2, r.deadSeat)
+    }
+
+    @Test
+    fun `dueling a good player kills the knight`() {
+        val r = resolver.resolve(board(), knightSeat = 1, targetSeat = 3)
+        assertFalse(r.targetIsWolf)
+        assertEquals(1, r.deadSeat)
+    }
+}

--- a/backend/src/test/kotlin/dev/robothanzo/werewolf/game/night/NightResolverTest.kt
+++ b/backend/src/test/kotlin/dev/robothanzo/werewolf/game/night/NightResolverTest.kt
@@ -1,7 +1,9 @@
 package dev.robothanzo.werewolf.game.night
 
+import dev.robothanzo.werewolf.game.roles.RoleIds.DEMON_HUNTER
 import dev.robothanzo.werewolf.game.roles.RoleIds.SEER
 import dev.robothanzo.werewolf.game.roles.RoleIds.VILLAGER
+import dev.robothanzo.werewolf.game.roles.RoleIds.WITCH
 import dev.robothanzo.werewolf.game.roles.RoleIds.WOLF
 import dev.robothanzo.werewolf.support.TestFixtures.registry
 import dev.robothanzo.werewolf.support.TestFixtures.seat
@@ -164,6 +166,44 @@ class NightResolverTest {
         )
         // save voided → 9 dies; poison voided → 6 lives
         assertEquals(setOf(9), r.deadSeats)
+    }
+
+    @Test
+    fun `女巫自救被禁止時仍死亡`() {
+        // wolves knife the witch (seat 5); she saves herself → blocked by default 房規, so she dies.
+        val s = session(
+            playerCount = 12,
+            seats = (1..12).map { if (it == 5) seat(it, WITCH to false) else seat(it, VILLAGER to false) },
+        )
+        val r = resolver.resolve(
+            NightDeclarations(wolfKill = NightAction(setOf(1), 5), witchActor = 5, witchSave = 5),
+            s,
+        )
+        assertEquals(setOf(5), r.deadSeats)
+    }
+
+    @Test
+    fun `女巫自救開啟時可自救`() {
+        val s = session(
+            playerCount = 12,
+            seats = (1..12).map { if (it == 5) seat(it, WITCH to false) else seat(it, VILLAGER to false) },
+        ) { settings.witchSelfSave = true }
+        val r = resolver.resolve(
+            NightDeclarations(wolfKill = NightAction(setOf(1), 5), witchActor = 5, witchSave = 5),
+            s,
+        )
+        assertTrue(r.deadSeats.isEmpty())
+    }
+
+    @Test
+    fun `獵魔人免疫女巫毒`() {
+        // seat 7 is a 獵魔人; the witch poisons it → immune (ROLES.md 獵魔人 被動), so it lives.
+        val s = session(
+            playerCount = 12,
+            seats = (1..12).map { if (it == 7) seat(it, DEMON_HUNTER to false) else seat(it, VILLAGER to false) },
+        )
+        val r = resolver.resolve(NightDeclarations(witchActor = 5, witchPoison = 7), s)
+        assertTrue(r.deadSeats.isEmpty())
     }
 
     @Test

--- a/backend/src/test/kotlin/dev/robothanzo/werewolf/game/roles/RoleRegistryTest.kt
+++ b/backend/src/test/kotlin/dev/robothanzo/werewolf/game/roles/RoleRegistryTest.kt
@@ -12,8 +12,9 @@ class RoleRegistryTest {
     private val registry = TestFixtures.registry()
 
     @Test
-    fun `all 27 canonical identities are registered`() {
-        assertEquals(27, registry.all.size)
+    fun `all canonical identities are registered`() {
+        // 27 FEATURES §2 identities + 隱狼 (ROLES.md).
+        assertEquals(28, registry.all.size)
     }
 
     @Test
@@ -58,6 +59,23 @@ class RoleRegistryTest {
         assertTrue(registry.require(RoleIds.WOLF).hasTag(RoleTag.WOLF_CHAT))
         assertTrue(registry.require(RoleIds.NIGHTMARE).hasTag(RoleTag.WOLF_CHAT))
         assertTrue(!registry.require(RoleIds.SEER).hasTag(RoleTag.WOLF_CHAT))
+    }
+
+    @Test
+    fun `non-recognizing wolves stay off the wolf chat`() {
+        // 機械狼 / 石像鬼 / 隱狼 互不相認 — wolf faction, but not on the chat relay.
+        assertTrue(!registry.require(RoleIds.MECHANIC_WOLF).hasTag(RoleTag.WOLF_CHAT))
+        assertTrue(!registry.require(RoleIds.GARGOYLE).hasTag(RoleTag.WOLF_CHAT))
+        assertTrue(!registry.require(RoleIds.HIDDEN_WOLF).hasTag(RoleTag.WOLF_CHAT))
+        assertEquals(Faction.WOLF, registry.factionOf(RoleIds.HIDDEN_WOLF))
+    }
+
+    @Test
+    fun `non-recognizing wolves inherit the knife`() {
+        assertTrue(registry.require(RoleIds.MECHANIC_WOLF).hasTag(RoleTag.INHERITS_KILL))
+        assertTrue(registry.require(RoleIds.GARGOYLE).hasTag(RoleTag.INHERITS_KILL))
+        assertTrue(registry.require(RoleIds.HIDDEN_WOLF).hasTag(RoleTag.INHERITS_KILL))
+        assertTrue(registry.require(RoleIds.HIDDEN_WOLF).hasTag(RoleTag.INVESTIGATED_AS_GOOD))
     }
 
     @Test

--- a/backend/src/test/kotlin/dev/robothanzo/werewolf/service/DayOrchestratorTest.kt
+++ b/backend/src/test/kotlin/dev/robothanzo/werewolf/service/DayOrchestratorTest.kt
@@ -1,0 +1,271 @@
+package dev.robothanzo.werewolf.service
+
+import dev.robothanzo.werewolf.discord.InteractionIds
+import dev.robothanzo.werewolf.discord.NicknameService
+import dev.robothanzo.werewolf.discord.NoOpDiscordGateway
+import dev.robothanzo.werewolf.domain.GameSession
+import dev.robothanzo.werewolf.game.flow.GameScheduler
+import dev.robothanzo.werewolf.game.speech.SpeechService
+import dev.robothanzo.werewolf.game.vote.PollEngine
+import dev.robothanzo.werewolf.game.vote.PollKind
+import dev.robothanzo.werewolf.game.vote.PollStage
+import dev.robothanzo.werewolf.game.win.WinConditionChecker
+import dev.robothanzo.werewolf.support.TestFixtures
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Drives the day-side flows (police election, expel vote, speech interrupt) end-to-end through the
+ * orchestrator against the [NoOpDiscordGateway], verifying the persisted [GameSession.speech] /
+ * [GameSession.poll] state transitions. [GameSessionService] is mocked so `mutate`/`find` operate on
+ * an in-memory session — no Spring context or Mongo needed.
+ */
+class DayOrchestratorTest {
+
+    private val msg = TestFixtures.msg()
+    private val roles = TestFixtures.registry()
+    private val gateway = NoOpDiscordGateway()
+    private val scheduler = GameScheduler()
+
+    private lateinit var session: GameSession
+    private lateinit var sessionService: GameSessionService
+    private lateinit var day: DayOrchestrator
+
+    private val gid = 1L
+
+    @BeforeEach
+    fun setup() {
+        // 1 wolf + 2 seers + 2 villagers: the game stays in progress after a single expel.
+        session = TestFixtures.session(
+            playerCount = 5,
+            seats = listOf(
+                TestFixtures.seat(1, "wolf" to false),
+                TestFixtures.seat(2, "seer" to false),
+                TestFixtures.seat(3, "seer" to false),
+                TestFixtures.seat(4, "villager" to false),
+                TestFixtures.seat(5, "villager" to false),
+            ),
+        ) { assigned = true }
+
+        sessionService = mock()
+        whenever(sessionService.find(any())).thenAnswer { session }
+        whenever(sessionService.mutate(any(), any<(GameSession) -> Any?>())).thenAnswer { inv ->
+            inv.getArgument<(GameSession) -> Any?>(1).invoke(session)
+        }
+        whenever(sessionService.log(any(), any(), any())).thenAnswer { null }
+
+        val announcer = CourtAnnouncer(gateway, msg)
+        val router = InteractionRouter(gateway)
+        day = DayOrchestrator(
+            sessionService = sessionService,
+            speeches = SpeechService(),
+            polls = PollEngine(),
+            win = WinConditionChecker(roles),
+            roles = roles,
+            nicknames = NicknameService(msg),
+            gateway = gateway,
+            scheduler = scheduler,
+            announcer = announcer,
+            router = router,
+            msg = msg,
+            deaths = DeathService(roles, NicknameService(msg), gateway),
+            duel = dev.robothanzo.werewolf.game.day.DuelResolver(roles),
+        )
+    }
+
+    @Test
+    fun `police election elects the most-voted candidate`() {
+        day.startPoliceElection(gid)
+        assertEquals(PollKind.POLICE, session.poll!!.kind)
+        assertEquals(PollStage.ENROLL, session.poll!!.stage)
+
+        // seats 1 and 2 enroll
+        day.handle(gid, 1, InteractionIds.POLICE_ENROLL, emptyList())
+        day.handle(gid, 2, InteractionIds.POLICE_ENROLL, emptyList())
+        assertEquals(setOf(1, 2), session.poll!!.candidates)
+
+        day.resolvePollStage(gid) // ENROLL -> CAMPAIGN (campaign speeches start)
+        assertEquals(PollStage.CAMPAIGN, session.poll!!.stage)
+        assertNotNull(session.speech)
+
+        day.stopSpeech(gid) // campaign speeches end -> CAMPAIGN -> WITHDRAW
+        assertEquals(PollStage.WITHDRAW, session.poll!!.stage)
+
+        day.resolvePollStage(gid) // WITHDRAW -> VOTING
+        assertEquals(PollStage.VOTING, session.poll!!.stage)
+
+        // non-candidate seats vote: 3 & 4 -> candidate 1, 5 -> candidate 2. The third (final) vote
+        // completes the poll and auto-resolves.
+        day.handle(gid, 3, "${InteractionIds.POLICE_VOTE}:1", emptyList())
+        day.handle(gid, 4, "${InteractionIds.POLICE_VOTE}:1", emptyList())
+        day.handle(gid, 5, "${InteractionIds.POLICE_VOTE}:2", emptyList())
+
+        assertEquals(1, session.policeSeat)
+        assertTrue(session.seat(1)!!.police)
+        assertNull(session.poll)
+    }
+
+    @Test
+    fun `expel vote kills the elected seat and opens last words`() {
+        day.startExpelVote(gid)
+        assertEquals(PollKind.EXPEL, session.poll!!.kind)
+        assertEquals(PollStage.VOTING, session.poll!!.stage)
+
+        // everyone votes seat 4; the final vote completes and resolves the poll
+        (1..5).forEach { day.handle(gid, it.toLong(), "${InteractionIds.EXPEL_VOTE}:4", emptyList()) }
+
+        assertFalse(session.seat(4)!!.alive)
+        assertNull(session.poll)
+        assertNotNull(session.speech)        // last-words flow
+        assertTrue(session.speech!!.lastWords)
+        assertEquals(listOf(4), session.speech!!.order)
+    }
+
+    @Test
+    fun `expel records the last expelled seat for the gravekeeper`() {
+        day.startExpelVote(gid)
+        (1..5).forEach { day.handle(gid, it.toLong(), "${InteractionIds.EXPEL_VOTE}:4", emptyList()) }
+        assertEquals(4, session.lastExpelledSeat)
+    }
+
+    @Test
+    fun `an expelled 白癡 flips its card and survives`() {
+        session = TestFixtures.session(
+            playerCount = 5,
+            seats = listOf(
+                TestFixtures.seat(1, "wolf" to false),
+                TestFixtures.seat(2, "seer" to false),
+                TestFixtures.seat(3, "villager" to false),
+                TestFixtures.seat(4, "idiot" to false) { idiot = true },
+                TestFixtures.seat(5, "villager" to false),
+            ),
+        ) { assigned = true }
+
+        day.startExpelVote(gid)
+        (1..5).forEach { day.handle(gid, it.toLong(), "${InteractionIds.EXPEL_VOTE}:4", emptyList()) }
+
+        assertTrue(session.seat(4)!!.alive)            // survives the expel
+        assertTrue(session.seat(4)!!.idiotRevealed)    // but is flipped (loses its vote)
+        assertNull(session.lastExpelledSeat)           // no real expel happened
+    }
+
+    @Test
+    fun `knight duel on a wolf kills the wolf and enters night`() {
+        // two wolves so killing one leaves the game in progress (the duel then forces night).
+        session = TestFixtures.session(
+            playerCount = 6,
+            seats = listOf(
+                TestFixtures.seat(1, "knight" to false),
+                TestFixtures.seat(2, "wolf" to false),
+                TestFixtures.seat(3, "wolf" to false),
+                TestFixtures.seat(4, "seer" to false),
+                TestFixtures.seat(5, "villager" to false),
+                TestFixtures.seat(6, "villager" to false),
+            ),
+        ) { assigned = true; phase = dev.robothanzo.werewolf.domain.Phase.SPEECHES }
+
+        val forceNight = day.knightDuel(gid, 1, 2)
+        assertTrue(forceNight)
+        assertFalse(session.seat(2)!!.alive)
+        assertEquals(dev.robothanzo.werewolf.domain.Phase.NIGHT, session.phase)
+    }
+
+    @Test
+    fun `knight duel on a good player kills the knight and stays in the day`() {
+        session = TestFixtures.session(
+            playerCount = 5,
+            seats = listOf(
+                TestFixtures.seat(1, "knight" to false),
+                TestFixtures.seat(2, "wolf" to false),
+                TestFixtures.seat(3, "seer" to false),
+                TestFixtures.seat(4, "villager" to false),
+                TestFixtures.seat(5, "villager" to false),
+            ),
+        ) { assigned = true; phase = dev.robothanzo.werewolf.domain.Phase.SPEECHES }
+
+        val forceNight = day.knightDuel(gid, 1, 3)
+        assertFalse(forceNight)
+        assertFalse(session.seat(1)!!.alive)
+        assertTrue(session.seat(3)!!.alive)
+        assertEquals(dev.robothanzo.werewolf.domain.Phase.SPEECHES, session.phase)
+    }
+
+    @Test
+    fun `白狼王 self-destruct arms its revenge and seals nothing`() {
+        session = TestFixtures.session(
+            playerCount = 5,
+            seats = listOf(
+                TestFixtures.seat(1, "white_wolf_king" to false),
+                TestFixtures.seat(2, "wolf" to false),
+                TestFixtures.seat(3, "seer" to false),
+                TestFixtures.seat(4, "villager" to false),
+                TestFixtures.seat(5, "villager" to false),
+            ),
+        ) { assigned = true; phase = dev.robothanzo.werewolf.domain.Phase.SPEECHES }
+
+        val forceNight = day.selfDestruct(gid, 1)
+        assertTrue(forceNight)
+        assertFalse(session.seat(1)!!.alive)
+        assertTrue(session.seat(1)!!.revengePending)
+        assertEquals(dev.robothanzo.werewolf.domain.Phase.NIGHT, session.phase)
+    }
+
+    @Test
+    fun `血月使徒 self-destruct seals the coming night`() {
+        session = TestFixtures.session(
+            playerCount = 5,
+            seats = listOf(
+                TestFixtures.seat(1, "blood_moon" to false),
+                TestFixtures.seat(2, "wolf" to false),
+                TestFixtures.seat(3, "seer" to false),
+                TestFixtures.seat(4, "villager" to false),
+                TestFixtures.seat(5, "villager" to false),
+            ),
+        ) { assigned = true; phase = dev.robothanzo.werewolf.domain.Phase.SPEECHES }
+
+        day.selfDestruct(gid, 1)
+        assertTrue(session.bloodMoonSeal)
+    }
+
+    @Test
+    fun `血月使徒 survives the expel when it is the last wolf`() {
+        session = TestFixtures.session(
+            playerCount = 5,
+            seats = listOf(
+                TestFixtures.seat(1, "blood_moon" to false),
+                TestFixtures.seat(2, "seer" to false),
+                TestFixtures.seat(3, "seer" to false),
+                TestFixtures.seat(4, "villager" to false),
+                TestFixtures.seat(5, "villager" to false),
+            ),
+        ) { assigned = true }
+
+        day.startExpelVote(gid)
+        (1..5).forEach { day.handle(gid, it.toLong(), "${InteractionIds.EXPEL_VOTE}:1", emptyList()) }
+
+        assertTrue(session.seat(1)!!.alive)             // survives once
+        assertTrue(session.seat(1)!!.bloodMoonRevived)
+        assertNull(session.lastExpelledSeat)
+    }
+
+    @Test
+    fun `speech interrupt majority advances to the next speaker`() {
+        day.startSpeeches(gid) // no police -> random direction, flow active immediately
+        val speaker = session.speech!!.order[session.speech!!.index]
+
+        // a strict majority of the 5 alive players (3) vote the speaker off
+        (1..5).filter { it != speaker }.take(3)
+            .forEach { day.handle(gid, it.toLong(), InteractionIds.SPEECH_INTERRUPT, emptyList()) }
+
+        // either advanced to the next speaker or the flow ended (single remaining speaker)
+        assertTrue(session.speech == null || session.speech!!.index >= 1)
+    }
+}

--- a/backend/src/test/kotlin/dev/robothanzo/werewolf/service/DeathServiceTest.kt
+++ b/backend/src/test/kotlin/dev/robothanzo/werewolf/service/DeathServiceTest.kt
@@ -1,0 +1,110 @@
+package dev.robothanzo.werewolf.service
+
+import dev.robothanzo.werewolf.discord.NicknameService
+import dev.robothanzo.werewolf.discord.NoOpDiscordGateway
+import dev.robothanzo.werewolf.game.roles.RoleIds.HIDDEN_WOLF
+import dev.robothanzo.werewolf.game.roles.RoleIds.HUNTER
+import dev.robothanzo.werewolf.game.roles.RoleIds.KNIGHT
+import dev.robothanzo.werewolf.game.roles.RoleIds.VILLAGER
+import dev.robothanzo.werewolf.game.roles.RoleIds.WHITE_WOLF_KING
+import dev.robothanzo.werewolf.game.roles.RoleIds.WOLF
+import dev.robothanzo.werewolf.game.roles.RoleIds.WOLF_BEAUTY
+import dev.robothanzo.werewolf.support.TestFixtures
+import dev.robothanzo.werewolf.support.TestFixtures.seat
+import dev.robothanzo.werewolf.support.TestFixtures.session
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DeathServiceTest {
+
+    private val service = DeathService(TestFixtures.registry(), NicknameService(TestFixtures.msg()), NoOpDiscordGateway())
+
+    @Test
+    fun `judge-killing a 獵人 arms its revenge`() {
+        val s = session(seats = listOf(seat(1, HUNTER to false)))
+        service.killSeat(s, 1, DeathCause.JUDGE)
+        assertTrue(s.seat(1)!!.revengePending)
+    }
+
+    @Test
+    fun `poison suppresses the 獵人 revenge`() {
+        val s = session(seats = listOf(seat(1, HUNTER to false)))
+        service.killSeat(s, 1, DeathCause.POISON, suppressRevenge = true)
+        assertFalse(s.seat(1)!!.revengePending)
+    }
+
+    @Test
+    fun `白狼王 only arms on self-destruct`() {
+        val expel = session(seats = listOf(seat(1, WHITE_WOLF_KING to false)))
+        service.killSeat(expel, 1, DeathCause.EXPEL)
+        assertFalse(expel.seat(1)!!.revengePending)
+
+        val boom = session(seats = listOf(seat(1, WHITE_WOLF_KING to false)))
+        service.killSeat(boom, 1, DeathCause.SELF_DESTRUCT)
+        assertTrue(boom.seat(1)!!.revengePending)
+    }
+
+    @Test
+    fun `狼美人 death cascades 殉情 onto the charmed seat`() {
+        val s = session(seats = listOf(
+            seat(1, WOLF_BEAUTY to false) { charmedSeat = 2 },
+            seat(2, VILLAGER to false),
+        ))
+        service.killSeat(s, 1, DeathCause.EXPEL)
+        assertFalse(s.seat(2)!!.alive)
+    }
+
+    @Test
+    fun `騎士 duel on the 狼美人 spares the charmed seat`() {
+        val s = session(seats = listOf(
+            seat(1, WOLF_BEAUTY to false) { charmedSeat = 2 },
+            seat(2, VILLAGER to false),
+        ))
+        service.killSeat(s, 1, DeathCause.KNIGHT_DUEL)
+        assertTrue(s.seat(2)!!.alive)
+    }
+
+    @Test
+    fun `邱比特 lovers 殉情 together`() {
+        val s = session(seats = listOf(
+            seat(1, KNIGHT to false) { loverSeat = 2 },
+            seat(2, VILLAGER to false) { loverSeat = 1 },
+        ))
+        service.killSeat(s, 1, DeathCause.JUDGE)
+        assertFalse(s.seat(2)!!.alive)
+    }
+
+    @Test
+    fun `隱狼 dies with the team when it does not inherit the knife`() {
+        val s = session(seats = listOf(
+            seat(1, WOLF to false),
+            seat(2, HIDDEN_WOLF to false),
+            seat(3, VILLAGER to false),
+        )) { settings.hiddenWolfInheritsKnife = false }
+        service.killSeat(s, 1, DeathCause.EXPEL)
+        assertFalse(s.seat(2)!!.alive) // 隱狼 falls with the last wolf
+    }
+
+    @Test
+    fun `隱狼 survives as the last wolf when it inherits the knife`() {
+        val s = session(seats = listOf(
+            seat(1, WOLF to false),
+            seat(2, HIDDEN_WOLF to false),
+            seat(3, VILLAGER to false),
+        )) { settings.hiddenWolfInheritsKnife = true }
+        service.killSeat(s, 1, DeathCause.EXPEL)
+        assertTrue(s.seat(2)!!.alive)
+    }
+
+    @Test
+    fun `killing a seat returns the full death list including cascade`() {
+        val s = session(seats = listOf(
+            seat(1, WOLF_BEAUTY to false) { charmedSeat = 2 },
+            seat(2, VILLAGER to false),
+        ))
+        val produced = service.killSeat(s, 1, DeathCause.EXPEL)
+        assertEquals(setOf(1, 2), produced.map { it.seat }.toSet())
+    }
+}

--- a/backend/src/test/kotlin/dev/robothanzo/werewolf/service/NightOrchestratorTest.kt
+++ b/backend/src/test/kotlin/dev/robothanzo/werewolf/service/NightOrchestratorTest.kt
@@ -1,0 +1,109 @@
+package dev.robothanzo.werewolf.service
+
+import dev.robothanzo.werewolf.discord.InteractionIds
+import dev.robothanzo.werewolf.discord.NicknameService
+import dev.robothanzo.werewolf.discord.NoOpDiscordGateway
+import dev.robothanzo.werewolf.domain.GameSession
+import dev.robothanzo.werewolf.game.flow.GameScheduler
+import dev.robothanzo.werewolf.game.night.NightDeclarationsBuilder
+import dev.robothanzo.werewolf.game.night.NightPlanner
+import dev.robothanzo.werewolf.game.night.NightResolver
+import dev.robothanzo.werewolf.game.roles.RoleIds
+import dev.robothanzo.werewolf.game.win.WinConditionChecker
+import dev.robothanzo.werewolf.support.TestFixtures
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Exercises the 機械狼 learn flow through [NightOrchestrator] against the [NoOpDiscordGateway], with
+ * [GameSessionService] mocked onto an in-memory session (no Spring / Mongo).
+ */
+class NightOrchestratorTest {
+
+    private val msg = TestFixtures.msg()
+    private val roles = TestFixtures.registry()
+    private val gateway = NoOpDiscordGateway()
+    private val scheduler = GameScheduler()
+
+    private lateinit var session: GameSession
+    private lateinit var sessionService: GameSessionService
+    private lateinit var night: NightOrchestrator
+
+    private val gid = 1L
+
+    private fun wire() {
+        sessionService = mock()
+        whenever(sessionService.find(any())).thenAnswer { session }
+        whenever(sessionService.mutate(any(), any<(GameSession) -> Any?>())).thenAnswer { inv ->
+            inv.getArgument<(GameSession) -> Any?>(1).invoke(session)
+        }
+        whenever(sessionService.log(any(), any(), any(), anyOrNull())).thenAnswer { null }
+
+        night = NightOrchestrator(
+            abilities = TestFixtures.allAbilities(),
+            planner = NightPlanner(),
+            resolver = NightResolver(roles),
+            declarations = NightDeclarationsBuilder(),
+            sessionService = sessionService,
+            win = WinConditionChecker(roles),
+            roles = roles,
+            gateway = gateway,
+            scheduler = scheduler,
+            msg = msg,
+            announcer = CourtAnnouncer(gateway, msg),
+            router = InteractionRouter(gateway),
+            deaths = DeathService(roles, NicknameService(msg), gateway),
+        )
+    }
+
+    @BeforeEach
+    fun setup() = wire()
+
+    @Test
+    fun `機械狼 learns the targeted identity`() {
+        session = TestFixtures.session(
+            playerCount = 5,
+            seats = listOf(
+                TestFixtures.seat(1, RoleIds.MECHANIC_WOLF to false),
+                TestFixtures.seat(2, RoleIds.WITCH to false),
+                TestFixtures.seat(3, RoleIds.SEER to false),
+                TestFixtures.seat(4, RoleIds.WOLF to false),
+                TestFixtures.seat(5, RoleIds.VILLAGER to false),
+            ),
+        ) { assigned = true; day = 2 }
+
+        night.startNight(gid)
+        night.handle(gid, 1L, "${InteractionIds.NIGHT_ACTION}:mechanic_wolf.learn", listOf("2"))
+        night.resolveNight(gid)
+
+        assertEquals(RoleIds.WITCH, session.seat(1)!!.learnedRoleId)
+    }
+
+    @Test
+    fun `機械狼 acts as its learned role on later nights`() {
+        // The mechanic has learned 女巫; no real 女巫 is on the board, so the planned witch ability
+        // can only come from the learned identity.
+        session = TestFixtures.session(
+            playerCount = 5,
+            seats = listOf(
+                TestFixtures.seat(1, RoleIds.MECHANIC_WOLF to false) { learnedRoleId = RoleIds.WITCH },
+                TestFixtures.seat(2, RoleIds.WOLF to false),
+                TestFixtures.seat(3, RoleIds.SEER to false),
+                TestFixtures.seat(4, RoleIds.VILLAGER to false),
+                TestFixtures.seat(5, RoleIds.VILLAGER to false),
+            ),
+        ) { assigned = true; day = 3 }
+
+        night.startNight(gid)
+
+        val planned = session.nightState.waves.flatten()
+        assertTrue("witch.potion" in planned, "expected the learned 女巫 ability to be planned: $planned")
+        assertTrue("mechanic_wolf.learn" !in planned, "the one-shot learn should be spent")
+    }
+}

--- a/backend/src/test/kotlin/dev/robothanzo/werewolf/support/TestFixtures.kt
+++ b/backend/src/test/kotlin/dev/robothanzo/werewolf/support/TestFixtures.kt
@@ -4,6 +4,8 @@ import dev.robothanzo.werewolf.domain.GameSession
 import dev.robothanzo.werewolf.domain.GameSettings
 import dev.robothanzo.werewolf.domain.IdentityCard
 import dev.robothanzo.werewolf.domain.Seat
+import dev.robothanzo.werewolf.game.night.NightAbility
+import dev.robothanzo.werewolf.game.night.abilities.*
 import dev.robothanzo.werewolf.game.roles.Role
 import dev.robothanzo.werewolf.game.roles.RoleRegistry
 import dev.robothanzo.werewolf.game.roles.impl.*
@@ -22,7 +24,7 @@ object TestFixtures {
         // wolves
         WolfRole(), WolfKingRole(), WolfBeautyRole(), WhiteWolfKingRole(),
         WolfBrotherRole(), WolfYoungerRole(), MechanicWolfRole(), NightmareRole(),
-        GargoyleRole(), BloodMoonRole(), EvilKnightRole(),
+        GargoyleRole(), BloodMoonRole(), EvilKnightRole(), HiddenWolfRole(),
         // gods
         SeerRole(), WitchRole(), HunterRole(), GuardRole(), KnightRole(), IdiotRole(),
         GravekeeperRole(), MagicianRole(), BlackMerchantRole(), PsychicRole(),
@@ -32,6 +34,13 @@ object TestFixtures {
     )
 
     fun registry(): RoleRegistry = RoleRegistry(allRoles(), msg())
+
+    /** Every canonical night-ability bean — for orchestrator/planner tests that need the full set. */
+    fun allAbilities(): List<NightAbility> = listOf(
+        MagicianSwap(), NightmareFear(), WolfKill(), GuardProtect(), SeerInvestigate(),
+        PsychicInvestigate(), GargoyleInvestigate(), WolfBeautyCharm(), BlackMerchantTrade(),
+        MechanicWolfLearn(), DemonHunterHunt(), WitchPotion(), GravekeeperPeek(), CupidBond(),
+    )
 
     fun seat(number: Int, vararg cards: Pair<String, Boolean>, configure: Seat.() -> Unit = {}): Seat =
         Seat(

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -53,10 +53,12 @@ export const api = {
   roles: () => request<RoleInfo[]>("/roles"),
 
   // members
-  members: (guildId: string, query = "") =>
+  members: (guildId: string, query = "", type = "") =>
     request<{ id: string; name: string; displayName: string; avatar: string | null }[]>(
-      `/sessions/${guildId}/members?query=${encodeURIComponent(query)}`,
+      `/sessions/${guildId}/members?query=${encodeURIComponent(query)}&type=${encodeURIComponent(type)}`,
     ),
+  updateMemberRole: (g: string, userId: string, role: "JUDGE" | "SPECTATOR" | "BLOCKED") =>
+    post(`/sessions/${g}/members/role`, { userId, role }),
 
   // game actions (each mutates then the server broadcasts a fresh snapshot)
   assign: (g: string) => post(`/sessions/${g}/assign`),
@@ -66,6 +68,11 @@ export const api = {
   pause: (g: string) => post(`/sessions/${g}/state/pause`),
   kill: (g: string, seat: number, identityIndex: number | null, allowLastWords: boolean) =>
     post(`/sessions/${g}/seats/${seat}/kill`, { identityIndex, allowLastWords }),
+  revenge: (g: string, seat: number, target: number) =>
+    post(`/sessions/${g}/seats/${seat}/revenge`, { target }),
+  duel: (g: string, seat: number, target: number) =>
+    post(`/sessions/${g}/seats/${seat}/duel`, { target }),
+  selfDestruct: (g: string, seat: number) => post(`/sessions/${g}/seats/${seat}/self-destruct`),
   revive: (g: string, seat: number, identityIndex: number | null) =>
     post(`/sessions/${g}/seats/${seat}/revive`, { identityIndex }),
   edit: (g: string, seat: number, roleIds: string[], orderLocked: boolean | null) =>
@@ -83,4 +90,14 @@ export const api = {
   setPool: (g: string, pool: Record<string, number>) => post(`/sessions/${g}/settings/pool`, { pool }),
   setDoubleIdentity: (g: string, value: boolean) => post(`/sessions/${g}/settings/double-identity`, { value }),
   setMuteAfterSpeech: (g: string, value: boolean) => post(`/sessions/${g}/settings/mute-after-speech`, { value }),
+  setWitchSelfSave: (g: string, value: boolean) => post(`/sessions/${g}/settings/witch-self-save`, { value }),
+  setHiddenWolfKnife: (g: string, value: boolean) => post(`/sessions/${g}/settings/hidden-wolf-knife`, { value }),
+
+  // day-side flow controls (mirror the Discord court buttons)
+  skipSpeaker: (g: string) => post(`/sessions/${g}/speech/skip`),
+  stopSpeech: (g: string) => post(`/sessions/${g}/speech/stop`),
+  setSpeechDirection: (g: string, direction: "UP" | "DOWN") =>
+    post(`/sessions/${g}/speech/direction`, { direction }),
+  advancePoll: (g: string) => post(`/sessions/${g}/poll/advance`),
+  resolvePoll: (g: string) => post(`/sessions/${g}/poll/resolve`),
 };

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -26,7 +26,8 @@ import {
   Compass,
   Cpu,
   Crosshair,
-  ShieldAlert
+  ShieldAlert,
+  EyeOff
 } from "lucide-react";
 
 type Size = "sm" | "md";
@@ -99,6 +100,8 @@ export function RoleIcon({ roleId, size = 14 }: { roleId: string; size?: number 
       return <Cpu {...iconProps} />;
     case "demon_hunter":
       return <Crosshair {...iconProps} />;
+    case "hidden_wolf":
+      return <EyeOff {...iconProps} />;
     default:
       return <User {...iconProps} />;
   }
@@ -128,16 +131,29 @@ export function FactionBadge({
   );
 }
 
-type StateKind = "police" | "gbaby" | "lock" | "dead";
+type StateKind = "police" | "gbaby" | "lock" | "dead" | "revenge" | "idiotRevealed" | "knife" | "charmed" | "lover" | "learned";
 
-export function StateBadge({ kind, size = "md" }: { kind: StateKind; size?: Size }) {
+export function StateBadge({ kind, size = "md", text }: { kind: StateKind; size?: Size; text?: string }) {
   const { t } = useTranslation();
-  const cls = ["wh-badge", `wh-badge--${kind === "dead" ? "lock" : kind}`, `wh-badge--${size}`].join(" ");
+  // Reuse existing faction-tinted chip styles for the new ROLES.md state badges.
+  const styleKind =
+    kind === "revenge" || kind === "knife" ? "wolf"
+      : kind === "charmed" || kind === "lover" ? "gbaby"
+      : kind === "idiotRevealed" || kind === "learned" ? "god"
+      : kind === "dead" ? "lock"
+      : kind;
+  const cls = ["wh-badge", `wh-badge--${styleKind}`, `wh-badge--${size}`].join(" ");
   const label: Record<StateKind, string> = {
     police: `⛨ ${t("badge.police")}`,
     gbaby: t("badge.gbaby"),
     lock: `鎖 ${t("badge.locked")}`,
     dead: t("badge.dead"),
+    revenge: t("badge.revenge"),
+    idiotRevealed: t("badge.idiotRevealed"),
+    knife: t("badge.knife"),
+    charmed: t("badge.charmed"),
+    lover: t("badge.lover"),
+    learned: text ? t("badge.learned", { role: text }) : t("badge.learnedShort"),
   };
   return <span className={cls}>{label[kind]}</span>;
 }

--- a/frontend/src/components/ui/PlayerCard.tsx
+++ b/frontend/src/components/ui/PlayerCard.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
-import type { Seat } from "@/types/snapshot";
+import type { Phase, Seat } from "@/types/snapshot";
 import { Avatar } from "./Avatar";
 import { FactionBadge, StateBadge } from "./Badge";
 import { Button } from "./Button";
@@ -9,28 +9,54 @@ interface PlayerCardProps {
   seat: Seat;
   changed?: boolean;
   readOnly?: boolean;
+  phase?: Phase;
+  /** Localized name of a 機械狼's learned identity, if any. */
+  learnedRoleName?: string;
+  /** When set, the whole card is a click target for the active revenge/duel pick. */
+  targeting?: boolean;
   onKill?: (identityIndex: number, identityName: string) => void;
   onRevive?: () => void;
   onEdit?: () => void;
   /** Click a struck-through dead identity to revive just it. */
   onReviveIdentity?: (identityIndex: number) => void;
+  onRevenge?: () => void;
+  onDuel?: () => void;
+  onSelfDestruct?: () => void;
+  onPickTarget?: () => void;
 }
 
 /**
  * The seat unit: avatar, seat name, identities in order (per-identity death strike, click a dead
- * identity to revive it), 警長/金寶寶/lock badges, and judge actions. Flashes `.wh-changed` when the
- * seat changed remotely; dims when fully dead.
+ * identity to revive it), 警長/金寶寶/lock + ROLES.md state badges, and judge actions (kill / revive
+ * / edit plus 開槍 / 決鬥 / 自爆). Flashes `.wh-changed` when the seat changed remotely; dims when
+ * fully dead. While a revenge/duel target is being picked, the card becomes a target button.
  */
-export function PlayerCard({ seat, changed, readOnly, onKill, onRevive, onEdit, onReviveIdentity }: PlayerCardProps) {
+export function PlayerCard({
+  seat, changed, readOnly, phase, learnedRoleName, targeting,
+  onKill, onRevive, onEdit, onReviveIdentity, onRevenge, onDuel, onSelfDestruct, onPickTarget,
+}: PlayerCardProps) {
   const { t } = useTranslation();
   const fullyDead = !seat.alive && !seat.unassigned;
   const anyDead = seat.identities.some((i) => i.dead);
+  const living = seat.identities.filter((i) => !i.dead);
+  const isWolf = living.some((i) => i.faction === "WOLF");
+  const isKnight = living.some((i) => i.roleId === "knight");
+
+  const canSelfDestruct = !readOnly && !fullyDead && !seat.unassigned && isWolf;
+  const canDuel = !readOnly && !fullyDead && isKnight && phase === "SPEECHES";
+  const canRevenge = !readOnly && seat.revengePending;
 
   return (
     <motion.div
       layout
       className={`wh-card ${changed ? "wh-changed" : ""}`}
-      style={{ padding: 14, display: "flex", flexDirection: "column", gap: 10, opacity: fullyDead ? 0.6 : 1 }}
+      onClick={targeting && !fullyDead && !seat.unassigned ? onPickTarget : undefined}
+      style={{
+        padding: 14, display: "flex", flexDirection: "column", gap: 10,
+        opacity: fullyDead ? 0.6 : 1,
+        cursor: targeting && !fullyDead && !seat.unassigned ? "crosshair" : "default",
+        outline: targeting && !fullyDead && !seat.unassigned ? "2px dashed var(--wolf-400)" : "none",
+      }}
     >
       <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
         <Avatar name={seat.displayName} avatar={seat.avatar} size="md" dead={fullyDead} unassigned={seat.unassigned} />
@@ -46,6 +72,12 @@ export function PlayerCard({ seat, changed, readOnly, onKill, onRevive, onEdit, 
           {seat.police && <StateBadge kind="police" size="sm" />}
           {seat.goldenBaby && <StateBadge kind="gbaby" size="sm" />}
           {seat.identities.length > 1 && seat.orderLocked && <StateBadge kind="lock" size="sm" />}
+          {seat.revengePending && <StateBadge kind="revenge" size="sm" />}
+          {seat.idiotRevealed && <StateBadge kind="idiotRevealed" size="sm" />}
+          {seat.knifeArmed && <StateBadge kind="knife" size="sm" />}
+          {seat.charmedSeat != null && <StateBadge kind="charmed" size="sm" />}
+          {seat.loverSeat != null && <StateBadge kind="lover" size="sm" />}
+          {seat.learnedRoleId && <StateBadge kind="learned" size="sm" text={learnedRoleName} />}
         </div>
       </div>
 
@@ -64,7 +96,7 @@ export function PlayerCard({ seat, changed, readOnly, onKill, onRevive, onEdit, 
       </div>
 
       {!readOnly && (
-        <div style={{ display: "flex", gap: 4, marginTop: "auto" }}>
+        <div style={{ display: "flex", gap: 4, marginTop: "auto", flexWrap: "wrap" }}>
           <Button size="sm" variant="danger" disabled={fullyDead || seat.unassigned} style={{ flex: 1 }} onClick={() => {
             const idx = seat.identities.findIndex((x) => !x.dead);
             if (idx >= 0) onKill?.(idx, seat.identities[idx].name);
@@ -79,6 +111,21 @@ export function PlayerCard({ seat, changed, readOnly, onKill, onRevive, onEdit, 
           <Button size="sm" variant="ghost" style={{ flex: 1 }} onClick={onEdit}>
             {t("dashboard.seatAction.edit")}
           </Button>
+          {canRevenge && (
+            <Button size="sm" variant="danger" style={{ flex: 1 }} onClick={onRevenge}>
+              {t("dashboard.seatAction.revenge")}
+            </Button>
+          )}
+          {canDuel && (
+            <Button size="sm" variant="secondary" style={{ flex: 1 }} onClick={onDuel}>
+              {t("dashboard.seatAction.duel")}
+            </Button>
+          )}
+          {canSelfDestruct && (
+            <Button size="sm" variant="ghost" armed armedLabel={t("dashboard.seatAction.selfDestruct")} style={{ flex: 1 }} onClick={onSelfDestruct}>
+              {t("dashboard.seatAction.selfDestruct")}
+            </Button>
+          )}
         </div>
       )}
     </motion.div>

--- a/frontend/src/hooks/useGameActions.ts
+++ b/frontend/src/hooks/useGameActions.ts
@@ -73,6 +73,49 @@ export function useGameActions(guildId: string, demo: boolean) {
           );
         } else void api.revive(guildId, seat, identityIndex);
       },
+      revenge: (seat: number, target: number) => {
+        if (demo) {
+          patch((snap) =>
+            recompute(
+              mapSeat(
+                mapSeat(snap, seat, (s) => ({ ...s, revengePending: false })),
+                target,
+                (s) => {
+                  const identities = s.identities.map((i, idx) => (idx === 0 ? { ...i, dead: true } : i));
+                  return { ...s, identities, alive: identities.some((i) => !i.dead) };
+                },
+              ),
+            ),
+          );
+        } else void api.revenge(guildId, seat, target);
+      },
+      duel: (seat: number, target: number) => {
+        if (demo) {
+          patch((snap) => {
+            const targetSeat = snap.seats.find((s) => s.seat === target);
+            const targetIsWolf = targetSeat?.identities.some((i) => i.faction === "WOLF") ?? false;
+            const dead = targetIsWolf ? target : seat;
+            return recompute(
+              mapSeat({ ...snap, phase: targetIsWolf ? "NIGHT" : snap.phase }, dead, (s) => {
+                const identities = s.identities.map((i, idx) => (idx === 0 ? { ...i, dead: true } : i));
+                return { ...s, identities, alive: identities.some((i) => !i.dead) };
+              }),
+            );
+          });
+        } else void api.duel(guildId, seat, target);
+      },
+      selfDestruct: (seat: number) => {
+        if (demo) {
+          patch((snap) =>
+            recompute(
+              mapSeat({ ...snap, phase: "NIGHT" }, seat, (s) => {
+                const identities = s.identities.map((i, idx) => (idx === 0 ? { ...i, dead: true } : i));
+                return { ...s, identities, alive: identities.some((i) => !i.dead) };
+              }),
+            ),
+          );
+        } else void api.selfDestruct(guildId, seat);
+      },
       pause: () => (demo ? patch((s) => ({ ...s, paused: !s.paused })) : void api.pause(guildId)),
       startGame: () => {
         if (demo) {
@@ -166,6 +209,10 @@ export function useGameActions(guildId: string, demo: boolean) {
          demo ? patch((s) => ({ ...s, doubleIdentity: value })) : void api.setDoubleIdentity(guildId, value),
       setMuteAfterSpeech: (value: boolean) =>
          demo ? patch((s) => ({ ...s, muteAfterSpeech: value })) : void api.setMuteAfterSpeech(guildId, value),
+      setWitchSelfSave: (value: boolean) =>
+         demo ? patch((s) => ({ ...s, witchSelfSave: value })) : void api.setWitchSelfSave(guildId, value),
+      setHiddenWolfKnife: (value: boolean) =>
+         demo ? patch((s) => ({ ...s, hiddenWolfInheritsKnife: value })) : void api.setHiddenWolfKnife(guildId, value),
       setPool: (pool: Record<string, number>) =>
          demo ? patch((s) => ({ ...s, pool })) : void api.setPool(guildId, pool),
       setPlayerCount: (count: number) => {
@@ -179,9 +226,18 @@ export function useGameActions(guildId: string, demo: boolean) {
           patch((s) => {
             const aliveSeats = s.seats.filter((seat) => seat.alive).map((seat) => seat.seat).sort((a, b) => a - b);
             if (aliveSeats.length === 0) return s;
-            const fromSeat = s.policeSeat && aliveSeats.includes(s.policeSeat) ? s.policeSeat : aliveSeats[0];
-            const startIdx = aliveSeats.indexOf(fromSeat);
-            const order = [...aliveSeats.slice(startIdx), ...aliveSeats.slice(0, startIdx)];
+            const police = s.policeSeat && aliveSeats.includes(s.policeSeat) ? s.policeSeat : null;
+            if (police) {
+              // mirror the backend: park on the police's direction choice
+              return {
+                ...s,
+                phase: "SPEECHES",
+                speech: { active: true, waiting: true, direction: "DOWN", fromSeat: police, speakerSeat: null, endsAt: null, order: [], upcoming: [] },
+                poll: null,
+              };
+            }
+            const fromSeat = aliveSeats[0];
+            const order = [...aliveSeats];
             return {
               ...s,
               phase: "SPEECHES",
@@ -212,7 +268,7 @@ export function useGameActions(guildId: string, demo: boolean) {
               speech: null,
               poll: {
                 kind: "POLICE",
-                stage: "VOTING",
+                stage: "ENROLL",
                 endsAt: Date.now() + 30000,
                 eligibleVoters: aliveSeats.length,
                 votesCast: 0,
@@ -273,26 +329,66 @@ export function useGameActions(guildId: string, demo: boolean) {
                 },
               };
             } else {
-              return {
-                ...s,
-                phase: "EXPEL_VOTE",
-                speech: null,
-              };
+              // flow complete: clear it but stay in the phase (the judge advances explicitly)
+              return { ...s, speech: null };
             }
           });
         } else {
-          void api.nextPhase(guildId);
+          void api.skipSpeaker(guildId);
         }
       },
       terminateSpeech: () => {
         if (demo) {
-          patch((s) => ({
-            ...s,
-            phase: "EXPEL_VOTE",
-            speech: null,
-          }));
+          patch((s) => ({ ...s, speech: null }));
         } else {
-          void api.nextPhase(guildId);
+          void api.stopSpeech(guildId);
+        }
+      },
+      setSpeechDirection: (direction: "UP" | "DOWN") => {
+        if (demo) {
+          patch((s) => {
+            if (!s.speech?.waiting) return s;
+            const aliveSeats = s.seats.filter((seat) => seat.alive).map((seat) => seat.seat).sort((a, b) => a - b);
+            const fromSeat = s.speech.fromSeat ?? aliveSeats[0];
+            const startIdx = Math.max(0, aliveSeats.indexOf(fromSeat));
+            const ordered =
+              direction === "DOWN"
+                ? [...aliveSeats.slice(startIdx), ...aliveSeats.slice(0, startIdx)]
+                : [aliveSeats[startIdx], ...aliveSeats.slice(0, startIdx).reverse(), ...aliveSeats.slice(startIdx + 1).reverse()];
+            return {
+              ...s,
+              speech: {
+                ...s.speech,
+                waiting: false,
+                direction,
+                speakerSeat: ordered[0],
+                endsAt: Date.now() + 60000,
+                order: ordered,
+                upcoming: ordered.slice(1),
+              },
+            };
+          });
+        } else {
+          void api.setSpeechDirection(guildId, direction);
+        }
+      },
+      advancePoll: () => {
+        if (demo) {
+          patch((s) => {
+            if (!s.poll) return s;
+            const order = ["ENROLL", "CAMPAIGN", "WITHDRAW", "VOTING", "RESOLVED"] as const;
+            const next = order[Math.min(order.length - 1, order.indexOf(s.poll.stage as any) + 1)];
+            return next === "RESOLVED" ? { ...s, poll: null } : { ...s, poll: { ...s.poll, stage: next } };
+          });
+        } else {
+          void api.advancePoll(guildId);
+        }
+      },
+      resolvePoll: () => {
+        if (demo) {
+          patch((s) => ({ ...s, poll: null }));
+        } else {
+          void api.resolvePoll(guildId);
         }
       },
       muteAll: () => {

--- a/frontend/src/i18n/zh-TW.json
+++ b/frontend/src/i18n/zh-TW.json
@@ -30,7 +30,8 @@
     "note": "本控制台僅供法官與旁觀者使用。在場玩家無法進入。",
     "loggedInAs": "已登入為 {{name}}",
     "selectServer": "選擇遊戲伺服器",
-    "notYou": "不是你？切換帳號"
+    "notYou": "不是你？切換帳號",
+    "viewDemo": "查看示範"
   },
   "servers": {
     "title": "選擇遊戲伺服器",
@@ -123,7 +124,7 @@
     "error": {
       "not_assigned": "身分尚未分配，請先進行身分分配"
     },
-    "seatAction": { "kill": "擊殺", "revive": "復活", "edit": "編輯" }
+    "seatAction": { "kill": "擊殺", "revive": "復活", "edit": "編輯", "revenge": "開槍", "duel": "決鬥", "selfDestruct": "自爆", "pickTarget": "選擇目標", "cancelTarget": "取消" }
   },
   "expel": {
     "running": "放逐投票進行中",
@@ -188,7 +189,9 @@
     },
     "withdrawn": "已退選",
     "noVotes": "尚無票",
-    "voteProgress": "投票進度"
+    "voteProgress": "投票進度",
+    "advanceStage": "推進階段",
+    "resolveNow": "立即結算"
   },
   "spectator": {
     "title": "上帝視角",
@@ -206,6 +209,10 @@
     "doubleIdentityDesc": "每位玩家獲得兩張身分",
     "muteAfterSpeech": "發言後靜音",
     "muteAfterSpeechDesc": "發言結束後自動伺服器靜音",
+    "witchSelfSave": "女巫可自救",
+    "witchSelfSaveDesc": "允許女巫對自己使用解藥（ROLES.md 女巫房規）",
+    "hiddenWolfKnife": "隱狼繼承狼刀",
+    "hiddenWolfKnifeDesc": "其餘狼人出局後，隱狼帶刀；關閉則隨隊伍一同死亡",
     "playerCount": "玩家數量",
     "applyCount": "套用人數變更",
     "pool": "身分板子",
@@ -258,6 +265,13 @@
     "idiot": "白癡",
     "locked": "已鎖定",
     "unlocked": "可調換",
-    "dead": "死亡"
+    "dead": "死亡",
+    "revenge": "待開槍",
+    "idiotRevealed": "已翻牌",
+    "knife": "帶刀",
+    "charmed": "被魅惑",
+    "lover": "情侶",
+    "learned": "已學習 {{role}}",
+    "learnedShort": "已學習"
   }
 }

--- a/frontend/src/mock/scenarios.ts
+++ b/frontend/src/mock/scenarios.ts
@@ -72,6 +72,12 @@ function buildSeat(spec: SeatSpec): Seat {
     clone: false,
     idiot: spec.ids.some(([n]) => n === "白癡"),
     orderLocked: spec.locked ?? true,
+    revengePending: false,
+    idiotRevealed: false,
+    loverSeat: null,
+    charmedSeat: null,
+    learnedRoleId: null,
+    knifeArmed: false,
   };
 }
 
@@ -124,6 +130,8 @@ export function buildScenario(scenario: ScenarioId): GameSnapshot {
     started: true,
     doubleIdentity: true,
     muteAfterSpeech: true,
+    witchSelfSave: false,
+    hiddenWolfInheritsKnife: true,
     assigned: true,
     policeSeat: 2,
     aliveCount: seats.filter((s) => s.alive).length,

--- a/frontend/src/screens/Dashboard.tsx
+++ b/frontend/src/screens/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
@@ -38,6 +38,14 @@ export function Dashboard() {
   const openEdit = useUiStore((s) => s.openEdit);
   const setLogVisible = useGameStore((s) => s.setLogPanelVisible);
   const actions = useGameActions(guildId, demo);
+
+  // Two-step revenge / duel: pick the actor, then click a target seat.
+  const [targeting, setTargeting] = useState<{ kind: "revenge" | "duel"; seat: number } | null>(null);
+  const roleNameById = useMemo(() => {
+    const m = new Map<string, string>();
+    snapshot?.seats.forEach((s) => s.identities.forEach((i) => m.set(i.roleId, i.name)));
+    return m;
+  }, [snapshot]);
 
   // The log panel is in view on the dashboard → mark logs read while here.
   useEffect(() => {
@@ -129,17 +137,37 @@ export function Dashboard() {
               ))}
             </span>
           </header>
+          {targeting && (
+            <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 12px", marginBottom: 10, borderRadius: "var(--r-sm)", background: "var(--wolf-dim)", border: "1px solid rgba(240,74,94,0.35)", fontSize: 12, fontWeight: 700, color: "var(--wolf-400)" }}>
+              {t("dashboard.seatAction.pickTarget")}（玩家{String(targeting.seat).padStart(2, "0")} · {t(`dashboard.seatAction.${targeting.kind}`)}）
+              <Button size="sm" variant="ghost" style={{ marginLeft: "auto" }} onClick={() => setTargeting(null)}>
+                {t("dashboard.seatAction.cancelTarget")}
+              </Button>
+            </div>
+          )}
           <motion.div layout style={{ display: "grid", gridTemplateColumns: `repeat(${cols[density]}, 1fr)`, gap: density === "compact" ? 10 : 12 }}>
             {snapshot.seats.map((seat) => (
               <PlayerCard
                 key={seat.seat}
                 seat={seat}
                 readOnly={readOnly}
+                phase={snapshot.phase}
+                learnedRoleName={seat.learnedRoleId ? roleNameById.get(seat.learnedRoleId) : undefined}
+                targeting={targeting != null && targeting.seat !== seat.seat}
                 changed={changedSeats.has(seat.seat)}
                 onKill={(idx, name) => openKill({ seat: seat.seat, identityIndex: idx, identityName: name })}
                 onRevive={() => actions.revive(seat.seat)}
                 onReviveIdentity={(idx) => actions.reviveIdentity(seat.seat, idx)}
                 onEdit={() => openEdit(seat.seat)}
+                onRevenge={() => setTargeting({ kind: "revenge", seat: seat.seat })}
+                onDuel={() => setTargeting({ kind: "duel", seat: seat.seat })}
+                onSelfDestruct={() => actions.selfDestruct(seat.seat)}
+                onPickTarget={() => {
+                  if (!targeting) return;
+                  if (targeting.kind === "revenge") actions.revenge(targeting.seat, seat.seat);
+                  else actions.duel(targeting.seat, seat.seat);
+                  setTargeting(null);
+                }}
               />
             ))}
           </motion.div>

--- a/frontend/src/screens/Settings.tsx
+++ b/frontend/src/screens/Settings.tsx
@@ -114,6 +114,8 @@ export function Settings() {
             <h2 className="wh-section-title">{t("settings.options")}</h2>
             <Switch checked={snapshot.doubleIdentity} onChange={actions.setDoubleIdentity} label={t("settings.doubleIdentity")} description={t("settings.doubleIdentityDesc")} />
             <Switch checked={snapshot.muteAfterSpeech} onChange={actions.setMuteAfterSpeech} label={t("settings.muteAfterSpeech")} description={t("settings.muteAfterSpeechDesc")} />
+            <Switch checked={snapshot.witchSelfSave} onChange={actions.setWitchSelfSave} label={t("settings.witchSelfSave")} description={t("settings.witchSelfSaveDesc")} />
+            <Switch checked={snapshot.hiddenWolfInheritsKnife} onChange={actions.setHiddenWolfKnife} label={t("settings.hiddenWolfKnife")} description={t("settings.hiddenWolfKnifeDesc")} />
             <div style={{ borderTop: "1px solid var(--border-1)", paddingTop: 14, display: "flex", flexDirection: "column", gap: 10 }}>
               <Stepper label={t("settings.playerCount")} value={count} min={4} max={20} onChange={setCount} dirty={dirty} />
               {dirty && (

--- a/frontend/src/types/snapshot.ts
+++ b/frontend/src/types/snapshot.ts
@@ -38,6 +38,13 @@ export interface Seat {
   clone: boolean;
   idiot: boolean;
   orderLocked: boolean;
+  // ROLES.md behavioural state (judge action buttons / state badges)
+  revengePending: boolean;
+  idiotRevealed: boolean;
+  loverSeat: number | null;
+  charmedSeat: number | null;
+  learnedRoleId: string | null;
+  knifeArmed: boolean;
 }
 
 export interface FactionMeter {
@@ -119,6 +126,8 @@ export interface GameSnapshot {
   started: boolean;
   doubleIdentity: boolean;
   muteAfterSpeech: boolean;
+  witchSelfSave: boolean;
+  hiddenWolfInheritsKnife: boolean;
   assigned: boolean;
   policeSeat: number | null;
   aliveCount: number;


### PR DESCRIPTION
Brings every `instructions/ROLES.md` role into behavioural compliance, adds a day-phase role-action layer, and surfaces it all on the judge dashboard. Targets `refactor`.

## Backend
- **Data model + tags** — persisted `Seat`/`GameSession`/`GameSettings` state (lover/charm bonds, revenge-pending, idiot-revealed, learned role, knife-armed, duel-used, blood-moon-revived; `witchSelfSave` / `hiddenWolfInheritsKnife` 房規); new `RoleTag`s `INVESTIGATED_AS_GOOD` / `INHERITS_KILL` / `REVENGE_ON_SELF_DESTRUCT_ONLY`; the new **隱狼** role.
- **Night resolver** — 女巫自救 房規 enforcement, 獵魔人 poison immunity, 通靈師/石像鬼 exact-identity reveal (following a 機械狼's learned id), charm/lover bond persistence.
- **守墓人** — DMs the last-expelled faction from night 2.
- **`DeathService`** — single shared death applier across night / judge / expel: arms 獵人/狼王/白狼王 revenge, cascades 殉情 (with the 騎士-duel exemption), applies 隱狼 auto-death. New `POST /seats/{seat}/revenge`.
- **Day actions** — 騎士 決鬥 (`DuelResolver`), 自爆 with the 血月使徒 night seal, 白癡 翻牌免疫放逐, 血月使徒 last-wolf expel survival. New duel/self-destruct endpoints.
- **Knife inheritance** for the 互不相認 大哥 wolves (石像鬼/隱狼/機械狼); **機械狼 learn-a-role** night ability (`Effect.LEARN`).

## Frontend
Snapshot types, 隱狼 Badge icon, revenge/duel/self-destruct actions (+ demo-mode patches) with a two-step target picker, per-seat state badges, 女巫自救 / 隱狼繼承狼刀 settings toggles, mock scenarios + i18n.

## Tests
New `DeathServiceTest`, `DuelResolverTest`, `NightOrchestratorTest`; extended `NightResolver`/`RoleRegistry`/`DayOrchestrator` suites. Frontend `typecheck` / `test` / `build` all green.

> ⚠️ `ApplicationContextTest` (embedded MongoDB) could not be run in the build sandbox — MongoDB's download CDN was network-blocked, so the embedded-Mongo binary couldn't be fetched. Every other backend suite and the full frontend pipeline pass. The new beans use only existing dependencies with no constructor cycles.

https://claude.ai/code/session_016FabsUtZN7uUVEx3cUZGKt